### PR TITLE
Add sigmoid router

### DIFF
--- a/d9d/module/block/moe/__init__.py
+++ b/d9d/module/block/moe/__init__.py
@@ -3,7 +3,7 @@
 from .grouped_experts import GroupedSwiGLU
 from .grouped_linear import GroupedLinear
 from .layer import MoELayer
-from .router import RoutingResult, TopKRouter
+from .router import RoutingResult, SigmoidGroupedTopKRouter, TopKRouter
 from .shared_expert import SharedExpertParameters, SharedSwiGLU
 
 __all__ = [
@@ -13,5 +13,6 @@ __all__ = [
     "RoutingResult",
     "SharedExpertParameters",
     "SharedSwiGLU",
+    "SigmoidGroupedTopKRouter",
     "TopKRouter",
 ]

--- a/d9d/module/block/moe/layer.py
+++ b/d9d/module/block/moe/layer.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import torch
 from torch import nn
 from torch.distributed import ProcessGroup
@@ -9,7 +11,7 @@ from .communications import (
     NoCommunicationHandler,
 )
 from .grouped_experts import GroupedSwiGLU
-from .router import RoutingResult, TopKRouter
+from .router import RoutingResult
 from .shared_expert import SharedExpertParameters, SharedSwiGLU
 
 
@@ -29,29 +31,23 @@ class MoELayer(nn.Module, ModuleLateInit):
         hidden_dim: int,
         intermediate_dim_grouped: int,
         num_grouped_experts: int,
-        top_k: int,
-        router_renormalize_probabilities: bool,
+        router: nn.Module,
         shared_expert: SharedExpertParameters | None = None,
     ):
         """
-         Constructs the MoELayer.
+        Constructs the MoELayer.
 
         Args:
             hidden_dim: Hidden size.
             intermediate_dim_grouped: Intermediate dimension for the Expert FFNs.
             num_grouped_experts: Total number of experts.
-            top_k: Number of experts to route each token to.
-            router_renormalize_probabilities: Configures router probability normalization behavior.
+            router: Router module. Must accept ``(num_tokens, hidden_dim)`` and return a
+                ``RoutingResult``. Use ``TopKRouter`` or ``SigmoidGroupedTopKRouter``.
             shared_expert: Optional configuration for a shared expert.
         """
 
         super().__init__()
-        self.router = TopKRouter(
-            dim=hidden_dim,
-            num_experts=num_grouped_experts,
-            top_k=top_k,
-            renormalize_probabilities=router_renormalize_probabilities,
-        )
+        self.router = router
         self.grouped_experts = GroupedSwiGLU(
             hidden_dim=hidden_dim, intermediate_dim=intermediate_dim_grouped, num_experts=num_grouped_experts
         )
@@ -77,11 +73,11 @@ class MoELayer(nn.Module, ModuleLateInit):
         Args:
             group: The PyTorch process group spanning the expert parallel ranks.
         """
-        # Lazy load the handler to prevent early DeepEP bindings/evaluation
         from .communications.deepep import DeepEpCommunicationHandler  # noqa: PLC0415
 
         communicator = DeepEpCommunicationHandler(num_experts=self._num_grouped_experts)
-        communicator.setup(group, self._hidden_dim, self.router.gate.weight.dtype)
+        gate = cast(nn.Linear, self.router.gate)
+        communicator.setup(group, self._hidden_dim, gate.weight.dtype)
         self._communicator = communicator
 
     @torch.no_grad()
@@ -133,7 +129,7 @@ class MoELayer(nn.Module, ModuleLateInit):
 
     def reset_parameters(self):
         """Resets module parameters."""
-        self.router.reset_parameters()
+        cast(ModuleLateInit, self.router).reset_parameters()
         self.grouped_experts.reset_parameters()
         if self.shared_expert is not None:
             self.shared_expert.reset_parameters()

--- a/d9d/module/block/moe/router.py
+++ b/d9d/module/block/moe/router.py
@@ -3,6 +3,7 @@ import dataclasses
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch.distributed.tensor import DTensor
 
 from d9d.module.base import ModuleLateInit
 
@@ -105,3 +106,118 @@ class TopKRouter(nn.Module, ModuleLateInit):
             nn.init.zeros_(self.expert_bias)
 
         self.gate.reset_parameters()
+
+
+class SigmoidGroupedTopKRouter(nn.Module, ModuleLateInit):
+    """
+    Selects top-K experts using sigmoid-activated scores with hierarchical group selection.
+
+    Used by the DeepSeek-V3 family (DSv3, GLM-4.6, Kimi K2/K2.6, MiniMax-M2, Mistral Large/Small 4).
+
+    Selection procedure per token:
+      1. Gate logits → sigmoid → raw per-expert probabilities (float32).
+      2. Add ``e_score_correction_bias`` to get selection scores (bias is not reflected in
+         the final expert weights — it is selection-only for load-balancing purposes).
+      3. Divide experts into ``n_group`` equal groups; compute each group's score as the sum
+         of its top-2 expert selection scores.
+      4. Keep the ``topk_group`` highest-scoring groups; mask out all other experts.
+      5. From the surviving experts run a final top-``top_k`` selection.
+      6. Gather weights from the unbiased sigmoid scores (step 1), not the biased scores.
+      7. Optionally renormalise to sum=1, then multiply by ``routed_scaling_factor``.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_experts: int,
+        top_k: int,
+        n_group: int,
+        topk_group: int,
+        routed_scaling_factor: float,
+        norm_topk_prob: bool,
+    ) -> None:
+        """
+        Constructs the SigmoidGroupedTopKRouter.
+
+        Args:
+            dim: Input feature dimensionality.
+            num_experts: Total number of routed experts. Must be divisible by ``n_group``.
+            top_k: Number of experts to select per token.
+            n_group: Number of expert groups. Experts are partitioned into contiguous groups
+                of size ``num_experts // n_group``.
+            topk_group: Number of groups whose experts are candidates for final top-k.
+            routed_scaling_factor: Scalar multiplied onto the final expert weights.
+            norm_topk_prob: If True, renormalise selected weights to sum to 1 before scaling.
+        """
+        super().__init__()
+        if num_experts % n_group != 0:
+            raise ValueError(f"num_experts ({num_experts}) must be divisible by n_group ({n_group})")
+
+        self.gate = nn.Linear(dim, num_experts, bias=False)
+        self.e_score_correction_bias = nn.Buffer(
+            torch.zeros(num_experts, dtype=torch.float32),
+            persistent=True,
+        )
+
+        self._num_experts = num_experts
+        self._top_k = top_k
+        self._n_group = n_group
+        self._topk_group = topk_group
+        self._experts_per_group = num_experts // n_group
+        self._routed_scaling_factor = routed_scaling_factor
+        self._norm_topk_prob = norm_topk_prob
+
+    def forward(self, hidden_states: torch.Tensor) -> RoutingResult:
+        """
+        Calculates routing decisions for the input tokens.
+
+        Args:
+            hidden_states: Input tokens. Shape: ``(num_tokens, dim)``.
+
+        Returns:
+            The routing result with selected expert indices and their (possibly scaled) weights.
+        """
+        num_tokens = hidden_states.shape[0]
+
+        scores = F.linear(hidden_states.float(), self.gate.weight.float()).sigmoid()
+
+        bias = self.e_score_correction_bias
+        if isinstance(bias, DTensor):
+            bias = bias.to_local()
+        scores_for_sel = scores + bias
+
+        # Group scoring: sum of top-2 expert scores within each group
+        grouped = scores_for_sel.view(num_tokens, self._n_group, self._experts_per_group)
+        group_scores = grouped.topk(min(2, self._experts_per_group), dim=-1)[0].sum(dim=-1)
+
+        # Select topk_group groups
+        group_idx = torch.topk(group_scores, k=self._topk_group, dim=-1, sorted=False)[1]
+
+        # Build expert-level boolean mask from selected groups
+        group_mask = torch.zeros_like(group_scores)
+        group_mask.scatter_(1, group_idx, 1.0)
+        expert_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(-1, -1, self._experts_per_group)
+            .reshape(num_tokens, self._num_experts)
+            .bool()
+        )
+
+        # Final top-k within surviving experts
+        masked_scores = scores_for_sel.masked_fill(~expert_mask, float("-inf"))
+        selected_indices = torch.topk(masked_scores, k=self._top_k, dim=-1, sorted=False)[1]
+
+        # Weights from unbiased scores (bias must not affect the FFN computation)
+        selected_weights = scores.gather(dim=-1, index=selected_indices)
+
+        if self._norm_topk_prob:
+            selected_weights = selected_weights / (selected_weights.sum(dim=-1, keepdim=True) + 1e-20)
+
+        selected_weights = selected_weights * self._routed_scaling_factor
+
+        return RoutingResult(selected_expert_indices=selected_indices, selected_probabilities=selected_weights)
+
+    def reset_parameters(self) -> None:
+        """Resets module parameters."""
+        self.gate.reset_parameters()
+        nn.init.zeros_(self.e_score_correction_bias)

--- a/d9d/module/model/qwen3_moe/decoder_layer.py
+++ b/d9d/module/model/qwen3_moe/decoder_layer.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from d9d.module.base import ModuleLateInit
 from d9d.module.block.attention import GroupedQueryAttention
-from d9d.module.block.moe import MoELayer
+from d9d.module.block.moe import MoELayer, TopKRouter
 from d9d.module.block.normalization import RMSNorm
 from d9d.module.block.positional import RotaryEmbeddingStyle
 
@@ -42,8 +42,12 @@ class Qwen3MoELayer(nn.Module, ModuleLateInit):
             hidden_dim=params.hidden_size,
             num_grouped_experts=params.num_experts,
             intermediate_dim_grouped=params.intermediate_size,
-            top_k=params.experts_top_k,
-            router_renormalize_probabilities=True,
+            router=TopKRouter(
+                dim=params.hidden_size,
+                num_experts=params.num_experts,
+                top_k=params.experts_top_k,
+                renormalize_probabilities=True,
+            ),
         )
 
         self.input_layernorm = RMSNorm(params.hidden_size, eps=params.rms_norm_eps)

--- a/deps/0007-dep-sigmoid-grouped-moe-router.md
+++ b/deps/0007-dep-sigmoid-grouped-moe-router.md
@@ -1,0 +1,157 @@
+---
+DEP: 0006
+Title: Sigmoid Grouped MoE Router
+Author: Illarion Iov
+Status: Implemented
+Type: Feature
+Created: 2026-05-18
+---
+
+# DEP-0006: Sigmoid Grouped MoE Router
+
+## Abstract
+
+This proposal adds `SigmoidGroupedTopKRouter` to `d9d/module/block/moe/router.py` — a router that
+combines sigmoid-activated expert scores with a two-level hierarchical selection procedure
+(group selection → per-group top-k). It also makes `MoELayer` router-agnostic by accepting any
+router instance via constructor injection instead of constructing `TopKRouter` internally.
+
+The new router is the routing strategy used by DeepSeek-V3, GLM-4.6, Kimi K2 / K2.6,
+MiniMax-M2, and Mistral Large 3 / Small 4 — all of which are planned for d9d integration.
+
+## Motivation
+
+The existing `TopKRouter` uses softmax gating: token scores across all experts are normalised
+jointly before top-k selection. Softmax introduces a coupling between experts that is absent in
+sigmoid gating, and it does not allow per-token load-balancing corrections to be applied without
+re-normalising the whole distribution.
+
+DeepSeek-V3 and its derivative models address this with a three-part change:
+
+1. **Sigmoid instead of softmax.** Each expert is scored independently; there is no
+   inter-expert normalisation before selection.
+2. **Hierarchical group selection.** Experts are divided into `n_group` equal groups. A group
+   score (sum of the top-2 expert scores within the group) selects `topk_group` candidate groups
+   first; the final top-k experts are drawn only from those groups. This constrains which experts
+   a token can reach and simplifies load balancing.
+3. **Correction bias.** An `e_score_correction_bias` buffer (one scalar per expert, not updated
+   by gradient) shifts expert scores before group and expert selection. It is updated externally
+   by a load-balancing controller. The final expert weights fed into the FFN use the unbiased
+   sigmoid scores — the bias is selection-only.
+
+Without this router, none of the DeepSeek-V3 family checkpoints can be loaded correctly into d9d.
+
+## Design Proposal
+
+### New class: `SigmoidGroupedTopKRouter`
+
+```python
+class SigmoidGroupedTopKRouter(nn.Module, ModuleLateInit):
+    def __init__(
+        self,
+        dim: int,
+        num_experts: int,
+        top_k: int,
+        n_group: int,
+        topk_group: int,
+        routed_scaling_factor: float,
+        norm_topk_prob: bool,
+    ) -> None: ...
+
+    def forward(self, hidden_states: torch.Tensor) -> RoutingResult: ...
+    def reset_parameters(self) -> None: ...
+```
+
+**Forward pass** (tokens shape `(T, dim)`):
+
+```
+scores      = sigmoid(gate(hidden_states))                      # (T, E),  float32
+scores_sel  = scores + e_score_correction_bias                  # (T, E)   — for selection only
+group_score = scores_sel.view(T, G, E/G).topk(2, -1)[0].sum(-1) # (T, G)
+group_idx   = topk(group_score, topk_group)[1]                  # (T, topk_group)
+expert_mask = scatter group_idx → (T, E) boolean mask
+masked      = scores_sel.masked_fill(~expert_mask, -inf)
+indices     = topk(masked, top_k)[1]                            # (T, top_k)
+weights     = scores.gather(-1, indices)                        # unbiased weights
+if norm_topk_prob: weights /= weights.sum(-1, keepdim=True) + ε
+weights    *= routed_scaling_factor
+return RoutingResult(indices, weights)
+```
+
+The `e_score_correction_bias` is a `nn.Buffer(persistent=True)`, initialised to zero. It is not
+a gradient parameter; callers update it via an external load-balancing controller.
+
+### Change to `MoELayer`
+
+`MoELayer` is refactored to be fully router-agnostic. `router` becomes a required positional
+argument; `router_renormalize_probabilities` and `top_k` are removed — both were
+`TopKRouter`-specific concerns that had leaked into the wrong class.
+
+```python
+def __init__(
+    self,
+    hidden_dim: int,
+    intermediate_dim_grouped: int,
+    num_grouped_experts: int,
+    router: nn.Module,
+    shared_expert: SharedExpertParameters | None = None,
+):
+    self.router = router  # plain assignment, no branching
+```
+
+All existing call sites are updated to construct their router explicitly before passing it.
+`reset_parameters` calls `self.router.reset_parameters()` and requires no changes.
+
+### Exports
+
+`SigmoidGroupedTopKRouter` is added to `d9d/module/block/moe/__init__.py` `__all__`.
+
+## Usage
+
+```python
+from d9d.module.block.moe import MoELayer, SigmoidGroupedTopKRouter, TopKRouter
+from d9d.module.block.moe.shared_expert import SharedExpertParameters
+
+# DeepSeek-V3 style
+moe = MoELayer(
+    hidden_dim=7168,
+    num_grouped_experts=256,
+    intermediate_dim_grouped=2048,
+    router=SigmoidGroupedTopKRouter(
+        dim=7168,
+        num_experts=256,
+        top_k=8,
+        n_group=8,
+        topk_group=4,
+        routed_scaling_factor=2.5,
+        norm_topk_prob=True,
+    ),
+    shared_expert=SharedExpertParameters(intermediate_size=2048),
+)
+
+# Qwen3 style (unchanged semantics, explicit construction)
+moe = MoELayer(
+    hidden_dim=4096,
+    num_grouped_experts=64,
+    intermediate_dim_grouped=1024,
+    router=TopKRouter(dim=4096, num_experts=64, top_k=4, renormalize_probabilities=True),
+)
+```
+
+## Backward Compatibility
+
+**Breaking change** to `MoELayer`: `router_renormalize_probabilities` and `top_k` are removed;
+`router` is now required. All in-tree call sites are updated in the same commit. There are no
+external callers in this codebase.
+
+## Alternatives Considered
+
+**Subclassing `TopKRouter`**: the two routers share only the `gate` linear and
+`RoutingResult` return type. A base class would add overhead without benefit.
+
+**`routing_type: Literal["softmax", "sigmoid_grouped"]` enum on `MoELayer`**:
+pushes router hyperparameters into `MoELayer`, coupling it to every future routing variant.
+
+**Optional `router=None` with internal fallback**: keeps the dead
+`router_renormalize_probabilities` / `top_k` params alive and adds a conditional. The required
+argument is cleaner and forces callers to be explicit about what router they are using.

--- a/test/d9d_test/modules/block/moe/test_deepep_safe.py
+++ b/test/d9d_test/modules/block/moe/test_deepep_safe.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 from d9d.module.block.moe.layer import MoELayer
+from d9d.module.block.moe.router import TopKRouter
 
 
 @pytest.mark.local
@@ -10,8 +11,7 @@ def test_deepep_not_imported_on_init():
         hidden_dim=128,
         intermediate_dim_grouped=256,
         num_grouped_experts=4,
-        top_k=2,
-        router_renormalize_probabilities=True,
+        router=TopKRouter(dim=128, num_experts=4, top_k=2, renormalize_probabilities=True),
     )
 
     assert "deep_ep_cpp" not in sys.modules

--- a/test/d9d_test/modules/block/moe/test_dist.py
+++ b/test/d9d_test/modules/block/moe/test_dist.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from d9d.core.dist_context import BATCH_DOMAIN, EXPERT_DOMAIN, DeviceMeshParameters
-from d9d.module.block.moe import MoELayer, SharedExpertParameters
+from d9d.module.block.moe import MoELayer, SharedExpertParameters, TopKRouter
 from d9d.module.parallelism.api import parallelize_expert_parallel
 
 from d9d_test.modules.block.moe.batch import MOE_HIDDEN_SIZE, build_moe_inputs, materialize_moe_inputs
@@ -25,8 +25,12 @@ def build_d9d_moe(dtype: torch.dtype, shared_expert_params: SharedExpertParamete
                 hidden_dim=MOE_HIDDEN_SIZE,
                 num_grouped_experts=_NUM_EXPERTS,
                 intermediate_dim_grouped=_MOE_INTERMEDIATE_SIZE,
-                top_k=_NUM_ACTIVATE_EXPERTS,
-                router_renormalize_probabilities=True,
+                router=TopKRouter(
+                    dim=MOE_HIDDEN_SIZE,
+                    num_experts=_NUM_EXPERTS,
+                    top_k=_NUM_ACTIVATE_EXPERTS,
+                    renormalize_probabilities=True,
+                ),
                 shared_expert=shared_expert_params,
             )
             .cuda()

--- a/test/d9d_test/modules/block/moe/test_hf_grouped_only.py
+++ b/test/d9d_test/modules/block/moe/test_hf_grouped_only.py
@@ -9,7 +9,7 @@ from d9d.model_state.mapper.leaf import (
     ModelStateMapperRename,
     ModelStateMapperTranspose,
 )
-from d9d.module.block.moe import MoELayer
+from d9d.module.block.moe import MoELayer, TopKRouter
 from torch import nn
 from transformers import Qwen3MoeConfig
 from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeSparseMoeBlock
@@ -60,8 +60,12 @@ def build_d9d_moe(dtype: torch.dtype) -> MoELayer:
                 hidden_dim=MOE_HIDDEN_SIZE,
                 num_grouped_experts=_NUM_EXPERTS,
                 intermediate_dim_grouped=_MOE_INTERMEDIATE_SIZE,
-                top_k=_NUM_ACTIVATE_EXPERTS,
-                router_renormalize_probabilities=True,
+                router=TopKRouter(
+                    dim=MOE_HIDDEN_SIZE,
+                    num_experts=_NUM_EXPERTS,
+                    top_k=_NUM_ACTIVATE_EXPERTS,
+                    renormalize_probabilities=True,
+                ),
             )
             .cuda()
             .to(dtype)

--- a/test/d9d_test/modules/block/moe/test_hf_grouped_shared.py
+++ b/test/d9d_test/modules/block/moe/test_hf_grouped_shared.py
@@ -9,7 +9,7 @@ from d9d.model_state.mapper.leaf import (
     ModelStateMapperRename,
     ModelStateMapperTranspose,
 )
-from d9d.module.block.moe import MoELayer, SharedExpertParameters
+from d9d.module.block.moe import MoELayer, SharedExpertParameters, TopKRouter
 from torch import nn
 from transformers import Qwen3_5MoeConfig
 from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeSparseMoeBlock
@@ -68,8 +68,12 @@ def build_d9d_moe_shared(dtype: torch.dtype) -> MoELayer:
                 hidden_dim=MOE_HIDDEN_SIZE,
                 num_grouped_experts=_NUM_EXPERTS,
                 intermediate_dim_grouped=_MOE_INTERMEDIATE_SIZE,
-                top_k=_NUM_ACTIVATE_EXPERTS,
-                router_renormalize_probabilities=True,
+                router=TopKRouter(
+                    dim=MOE_HIDDEN_SIZE,
+                    num_experts=_NUM_EXPERTS,
+                    top_k=_NUM_ACTIVATE_EXPERTS,
+                    renormalize_probabilities=True,
+                ),
                 shared_expert=SharedExpertParameters(
                     intermediate_size=_SHARED_EXPERT_INTERMEDIATE_SIZE,
                     enable_gate=True,

--- a/test/d9d_test/modules/block/moe/test_sigmoid_grouped_router.py
+++ b/test/d9d_test/modules/block/moe/test_sigmoid_grouped_router.py
@@ -1,0 +1,266 @@
+import pytest
+import torch
+from d9d.module.block.moe import MoELayer, SigmoidGroupedTopKRouter
+from torch import nn
+
+from d9d_test.modules.block.moe.batch import MOE_HIDDEN_SIZE
+from d9d_test.modules.helper import torch_seed
+
+_DIM = 64
+_NUM_EXPERTS = 16
+_N_GROUP = 4  # 4 groups of 4 experts each
+_TOPK_GROUP = 2  # select 2 groups
+_TOP_K = 4  # select 4 experts total
+_SCALING = 2.5
+_HF_NUM_EXPERTS = 32
+_HF_N_GROUP = 4
+_HF_TOPK_GROUP = 2
+_HF_TOP_K = 4
+_HF_SCALING = 2.5
+
+
+def _make_router(
+    *,
+    norm_topk_prob: bool = True,
+    routed_scaling_factor: float = _SCALING,
+    num_experts: int = _NUM_EXPERTS,
+    n_group: int = _N_GROUP,
+    topk_group: int = _TOPK_GROUP,
+    top_k: int = _TOP_K,
+) -> SigmoidGroupedTopKRouter:
+    torch.manual_seed(0)
+    router = SigmoidGroupedTopKRouter(
+        dim=_DIM,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=routed_scaling_factor,
+        norm_topk_prob=norm_topk_prob,
+    )
+    router.reset_parameters()
+    return router
+
+
+def test_output_shapes():
+    router = _make_router()
+    num_tokens = 32
+    x = torch.randn(num_tokens, _DIM)
+    result = router(x)
+    assert result.selected_expert_indices.shape == (num_tokens, _TOP_K)
+    assert result.selected_probabilities.shape == (num_tokens, _TOP_K)
+
+
+def test_indices_dtype_is_int():
+    router = _make_router()
+    result = router(torch.randn(8, _DIM))
+    assert result.selected_expert_indices.dtype in {torch.int32, torch.int64}
+
+
+def test_weights_dtype_is_float32():
+    router = _make_router()
+    result = router(torch.randn(8, _DIM))
+    assert result.selected_probabilities.dtype == torch.float32
+
+
+def test_indices_in_valid_range():
+    router = _make_router()
+    result = router(torch.randn(64, _DIM))
+    assert result.selected_expert_indices.min() >= 0
+    assert result.selected_expert_indices.max() < _NUM_EXPERTS
+
+
+def test_group_constraint():
+    """Every token's selected experts must all fall within at most topk_group groups."""
+    router = _make_router()
+    result = router(torch.randn(128, _DIM))
+
+    experts_per_group = _NUM_EXPERTS // _N_GROUP
+    group_ids = result.selected_expert_indices // experts_per_group  # (T, top_k)
+    for token_group_ids in group_ids:
+        unique_groups = token_group_ids.unique()
+        assert unique_groups.numel() <= _TOPK_GROUP, (
+            f"Token routed to {unique_groups.numel()} groups, expected ≤ {_TOPK_GROUP}"
+        )
+
+
+def test_no_duplicate_experts_per_token():
+    router = _make_router()
+    result = router(torch.randn(64, _DIM))
+    for row in result.selected_expert_indices:
+        assert row.unique().numel() == _TOP_K, "Duplicate expert selected for a single token"
+
+
+def test_norm_topk_prob_weights_sum_to_one():
+    router = _make_router(norm_topk_prob=True, routed_scaling_factor=1.0)
+    result = router(torch.randn(64, _DIM))
+    sums = result.selected_probabilities.sum(dim=-1)
+    torch.testing.assert_close(sums, torch.ones_like(sums), atol=1e-5, rtol=0)
+
+
+def test_routed_scaling_factor_applied():
+    """Weights with scale=k should be exactly k times the scale=1 weights."""
+    x = torch.randn(32, _DIM)
+    router1 = _make_router(norm_topk_prob=True, routed_scaling_factor=1.0)
+    router2 = _make_router(norm_topk_prob=True, routed_scaling_factor=_SCALING)
+    r1 = router1(x)
+    r2 = router2(x)
+    assert torch.equal(r1.selected_expert_indices, r2.selected_expert_indices)
+    torch.testing.assert_close(r2.selected_probabilities, r1.selected_probabilities * _SCALING)
+
+
+def test_correction_bias_affects_selection_not_weights():
+    """
+    e_score_correction_bias shifts which experts are chosen but must NOT change the
+    weight values of the selected experts (weights come from unbiased sigmoid scores).
+    """
+    torch.manual_seed(7)
+    x = torch.randn(64, _DIM)
+
+    router_no_bias = _make_router(norm_topk_prob=False, routed_scaling_factor=1.0)
+    router_biased = _make_router(norm_topk_prob=False, routed_scaling_factor=1.0)
+    # Force expert 0 to always win selection in the biased router
+    router_biased.e_score_correction_bias[0] = 1e6
+
+    r_no = router_no_bias(x)
+    r_bi = router_biased(x)
+
+    assert (r_bi.selected_expert_indices == 0).any(), "Bias should have forced expert 0 into selection"
+
+    # For positions where the same expert index appears in both results, the weight
+    # must be identical (same unbiased sigmoid score, same gate weights).
+    for t in range(x.shape[0]):
+        no_idx = r_no.selected_expert_indices[t]
+        bi_idx = r_bi.selected_expert_indices[t]
+        for pos_bi, expert in enumerate(bi_idx):
+            pos_no = (no_idx == expert).nonzero(as_tuple=True)[0]
+            if pos_no.numel() > 0:
+                torch.testing.assert_close(
+                    r_bi.selected_probabilities[t, pos_bi],
+                    r_no.selected_probabilities[t, pos_no[0]],
+                    atol=1e-6,
+                    rtol=0,
+                    msg=f"Token {t}, expert {expert}: weight differs despite identical gate weights",
+                )
+
+
+def test_invalid_n_group_raises():
+    with pytest.raises(ValueError, match="divisible"):
+        SigmoidGroupedTopKRouter(
+            dim=64,
+            num_experts=15,
+            top_k=4,
+            n_group=4,
+            topk_group=2,
+            routed_scaling_factor=1.0,
+            norm_topk_prob=True,
+        )
+
+
+def test_moe_layer_with_sigmoid_router():
+    """MoELayer with SigmoidGroupedTopKRouter should produce valid output shapes."""
+    hidden_dim = 64
+    moe = MoELayer(
+        hidden_dim=hidden_dim,
+        num_grouped_experts=16,
+        intermediate_dim_grouped=128,
+        router=SigmoidGroupedTopKRouter(
+            dim=hidden_dim,
+            num_experts=16,
+            top_k=4,
+            n_group=4,
+            topk_group=2,
+            routed_scaling_factor=2.5,
+            norm_topk_prob=True,
+        ),
+    )
+    moe.reset_parameters()
+    out = moe(torch.randn(8, 32, hidden_dim))
+    assert out.shape == (8, 32, hidden_dim)
+
+
+def _hf_route_reference(
+    hidden_states: torch.Tensor,
+    gate_weight: torch.Tensor,
+    correction_bias: torch.Tensor,
+    n_group: int,
+    topk_group: int,
+    top_k: int,
+    norm_topk_prob: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Self-contained re-implementation of HF DSv3 routing logic for test reference."""
+    num_experts = gate_weight.shape[0]
+    experts_per_group = num_experts // n_group
+    num_tokens = hidden_states.shape[0]
+
+    scores = (hidden_states.float() @ gate_weight.float().T).sigmoid()
+    scores_for_sel = scores + correction_bias
+
+    group_scores = scores_for_sel.view(num_tokens, n_group, experts_per_group).topk(2, dim=-1)[0].sum(dim=-1)
+    group_idx = torch.topk(group_scores, k=topk_group, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores).scatter_(1, group_idx, 1.0)
+    expert_mask = group_mask.unsqueeze(-1).expand(-1, -1, experts_per_group).reshape(num_tokens, num_experts).bool()
+    masked = scores_for_sel.masked_fill(~expert_mask, float("-inf"))
+    indices = torch.topk(masked, k=top_k, sorted=False)[1]
+    weights = scores.gather(1, indices)
+    if norm_topk_prob:
+        weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
+    weights = weights * routed_scaling_factor
+    return indices, weights
+
+
+@pytest.mark.local
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_consistent_with_hf_dsv3_routing_reference(dtype: torch.dtype):
+    """
+    d9d SigmoidGroupedTopKRouter must produce the same routing indices and expert weights
+    as the HF DeepSeek-V3 routing reference when given identical gate weights and inputs.
+    """
+    with torch_seed(99):
+        gate = nn.Linear(MOE_HIDDEN_SIZE, _HF_NUM_EXPERTS, bias=False).cuda().to(dtype)
+        correction_bias = torch.zeros(_HF_NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+        router = (
+            SigmoidGroupedTopKRouter(
+                dim=MOE_HIDDEN_SIZE,
+                num_experts=_HF_NUM_EXPERTS,
+                top_k=_HF_TOP_K,
+                n_group=_HF_N_GROUP,
+                topk_group=_HF_TOPK_GROUP,
+                routed_scaling_factor=_HF_SCALING,
+                norm_topk_prob=True,
+            )
+            .cuda()
+            .to(dtype)
+        )
+
+        # Share exact gate weights
+        router.gate.weight.data.copy_(gate.weight.data)
+        router.e_score_correction_bias.copy_(correction_bias)
+
+        x = torch.randn(_HF_NUM_EXPERTS * 4, MOE_HIDDEN_SIZE, device="cuda", dtype=dtype)
+
+    ref_indices, ref_weights = _hf_route_reference(
+        x,
+        gate.weight,
+        correction_bias,
+        n_group=_HF_N_GROUP,
+        topk_group=_HF_TOPK_GROUP,
+        top_k=_HF_TOP_K,
+        norm_topk_prob=True,
+        routed_scaling_factor=_HF_SCALING,
+    )
+    d9d_result = router(x)
+
+    # Sort by index before comparing (topk order may differ)
+    ref_order = ref_indices.argsort(dim=-1)
+    d9d_order = d9d_result.selected_expert_indices.argsort(dim=-1)
+
+    ref_indices_sorted = ref_indices.gather(1, ref_order)
+    d9d_indices_sorted = d9d_result.selected_expert_indices.gather(1, d9d_order)
+    assert torch.equal(ref_indices_sorted, d9d_indices_sorted), "Routing indices differ from reference"
+
+    ref_weights_sorted = ref_weights.gather(1, ref_order)
+    d9d_weights_sorted = d9d_result.selected_probabilities.gather(1, d9d_order)
+    torch.testing.assert_close(d9d_weights_sorted, ref_weights_sorted, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Add sigmoid router for Deepseek V3
Breaks existing moe layer interface to implement router-agnostic moe layer, includes fixes to qwen3 moe