### PR TITLE
feat: allow arbitrary PyTrees to be passed between pipeline stages

### DIFF
--- a/d9d/loop/component/task_operator/common.py
+++ b/d9d/loop/component/task_operator/common.py
@@ -1,12 +1,21 @@
-from d9d.core.types import MicrobatchPack
+import typing
+
+from d9d.core.types import MicrobatchPack, PyTree
 from d9d.loop.control import BaseTask, BuildForwardInputsContext
 
 from ..pipeline_state import PipelineStateHandler
 
+TBatch = typing.TypeVar("TBatch", bound=PyTree)
+TPipelineInput = typing.TypeVar("TPipelineInput")
+TSharedInput = typing.TypeVar("TSharedInput")
+TState = typing.TypeVar("TState", bound=PyTree)
+
 
 def build_pipeline_microbatch_inputs(
-    task: BaseTask, pipeline_state: PipelineStateHandler, pack: MicrobatchPack
-) -> tuple[tuple[dict, ...], tuple[dict, ...]]:
+    task: BaseTask[TBatch, TPipelineInput, TSharedInput, TState],
+    pipeline_state: PipelineStateHandler[TState],
+    pack: MicrobatchPack,
+) -> tuple[tuple[TPipelineInput, ...], tuple[TSharedInput, ...]]:
     """Builds the per-microbatch model inputs for a whole pack, storing each microbatch's side-data.
 
     Args:
@@ -15,15 +24,15 @@ def build_pipeline_microbatch_inputs(
         pack: The step's pack of raw microbatches.
 
     Returns:
-        A tuple of per-microbatch input dicts and a tuple of per-microbatch kwarg dicts.
+        A tuple of per-microbatch ``PipelineInput`` and a tuple of per-microbatch ``SharedInput``.
     """
     inputs_microbatches = []
-    kwargs_microbatches = []
+    shared_microbatches = []
 
     for microbatch_idx, microbatch in enumerate(pack):
         model_inputs = task.build_forward_inputs(BuildForwardInputsContext(batch=microbatch))
         pipeline_state.store(microbatch_idx, model_inputs.state)
-        inputs_microbatches.append(model_inputs.inputs)
-        kwargs_microbatches.append(model_inputs.kwargs)
+        inputs_microbatches.append(model_inputs.input)
+        shared_microbatches.append(model_inputs.shared)
 
-    return tuple(inputs_microbatches), tuple(kwargs_microbatches)
+    return tuple(inputs_microbatches), tuple(shared_microbatches)

--- a/d9d/loop/component/task_operator/inference.py
+++ b/d9d/loop/component/task_operator/inference.py
@@ -1,22 +1,32 @@
-import torch
+import typing
 
 from d9d.core.dist_context import DistributedContext
-from d9d.core.types import MicrobatchPack
+from d9d.core.types import MicrobatchPack, PyTree
 from d9d.loop.control import InferenceTask, ProcessOutputsContext
 from d9d.pipelining.factory.factory import PipelineScheduleInfo
 
 from ..pipeline_state import PipelineStateHandler
 from .common import build_pipeline_microbatch_inputs
 
+TBatch = typing.TypeVar("TBatch", bound=PyTree)
+TPipelineInput = typing.TypeVar("TPipelineInput")
+TSharedInput = typing.TypeVar("TSharedInput")
+TPipelineOutput = typing.TypeVar("TPipelineOutput")
+TState = typing.TypeVar("TState", bound=PyTree)
 
-class InferenceProcessor:
+
+class InferenceProcessor(typing.Generic[TPipelineOutput, TState]):
     """Handles the processing of model outputs during inference or evaluation.
 
     This component retrieves the per-microbatch state and delegates the output processing logic to the
     user-defined inference task.
     """
 
-    def __init__(self, state: PipelineStateHandler, task: InferenceTask):
+    def __init__(
+        self,
+        state: PipelineStateHandler[TState],
+        task: InferenceTask[typing.Any, typing.Any, typing.Any, TPipelineOutput, TState],
+    ):
         """Constructs a new InferenceProcessor.
 
         Args:
@@ -26,26 +36,26 @@ class InferenceProcessor:
         self._state = state
         self._task = task
 
-    def __call__(self, pipeline_outputs: dict[str, torch.Tensor], microbatch_idx: int) -> None:
+    def __call__(self, pipeline_outputs: TPipelineOutput, microbatch_idx: int) -> None:
         """Processes model outputs for a specific microbatch.
 
         Args:
-            pipeline_outputs: Dictionary containing model output tensors.
+            pipeline_outputs: The ``PipelineOutput`` produced by the last stage.
             microbatch_idx: Index of the current microbatch within the step's pack.
         """
         with self._state.scope(microbatch_idx) as state:
             self._task.process_outputs(ProcessOutputsContext(pipeline_results=pipeline_outputs, state=state))
 
 
-class InferenceTaskOperator:
+class InferenceTaskOperator(typing.Generic[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState]):
     """Orchestrates the forward pass for an inference task over one pack."""
 
     def __init__(
         self,
         dist_context: DistributedContext,
-        task: InferenceTask,
-        pipeline: PipelineScheduleInfo,
-        pipeline_state: PipelineStateHandler,
+        task: InferenceTask[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState],
+        pipeline: PipelineScheduleInfo[TPipelineInput, TSharedInput, TPipelineOutput],
+        pipeline_state: PipelineStateHandler[TState],
     ):
         """Constructs the InferenceTaskOperator.
 
@@ -60,19 +70,19 @@ class InferenceTaskOperator:
         self._pipeline = pipeline
         self._pipeline_state = pipeline_state
 
-    def forward(self, pack: MicrobatchPack) -> None:
+    def forward(self, pack: MicrobatchPack[TBatch]) -> None:
         """Executes the forward pass for one pack of microbatches.
 
         Args:
             pack: The step's pack of raw microbatches.
         """
         try:
-            inputs_microbatches, kwargs_microbatches = build_pipeline_microbatch_inputs(
+            inputs_microbatches, shared_microbatches = build_pipeline_microbatch_inputs(
                 self._task, self._pipeline_state, pack
             )
             self._pipeline.schedule.step(
                 inputs_microbatches=inputs_microbatches,
-                kwargs_microbatches=kwargs_microbatches,
+                shared_microbatches=shared_microbatches,
                 callback=InferenceProcessor(task=self._task, state=self._pipeline_state),
             )
         finally:

--- a/d9d/loop/component/task_operator/train.py
+++ b/d9d/loop/component/task_operator/train.py
@@ -1,7 +1,9 @@
+import typing
+
 import torch
 
 from d9d.core.dist_context import DistributedContext
-from d9d.core.types import MicrobatchPack
+from d9d.core.types import MicrobatchPack, PyTree
 from d9d.loop.control import ComputeLossContext, TrainTask, UpdateMetricsContext
 from d9d.metric.impl.container import ComposeMetric
 from d9d.pipelining.factory.factory import PipelineScheduleInfo
@@ -11,8 +13,14 @@ from ..job_schedule import JobSchedule
 from ..pipeline_state import PipelineStateHandler
 from .common import build_pipeline_microbatch_inputs
 
+TBatch = typing.TypeVar("TBatch", bound=PyTree)
+TPipelineInput = typing.TypeVar("TPipelineInput")
+TSharedInput = typing.TypeVar("TSharedInput")
+TPipelineOutput = typing.TypeVar("TPipelineOutput")
+TState = typing.TypeVar("TState", bound=PyTree)
 
-class LossComputer:
+
+class LossComputer(typing.Generic[TPipelineOutput, TState]):
     """Computes and accumulates the training loss for each microbatch of a step.
 
     This component bridges the raw outputs of the model pipeline and the user-defined training task.
@@ -20,8 +28,8 @@ class LossComputer:
 
     def __init__(
         self,
-        state: PipelineStateHandler,
-        task: TrainTask,
+        state: PipelineStateHandler[TState],
+        task: TrainTask[typing.Any, typing.Any, typing.Any, TPipelineOutput, TState],
         schedule: JobSchedule,
         gradient_manager: GradientManager,
         metrics: ComposeMetric,
@@ -41,11 +49,11 @@ class LossComputer:
         self._gradient_manager = gradient_manager
         self._metrics = metrics
 
-    def __call__(self, pipeline_outputs: dict[str, torch.Tensor], microbatch_idx: int) -> torch.Tensor:
+    def __call__(self, pipeline_outputs: TPipelineOutput, microbatch_idx: int) -> torch.Tensor:
         """Computes the weighted loss for a microbatch and accumulates its loss/weight and metrics.
 
         Args:
-            pipeline_outputs: Dictionary containing model output tensors.
+            pipeline_outputs: The ``PipelineOutput`` produced by the last stage.
             microbatch_idx: Index of the current microbatch within the step's pack.
 
         Returns:
@@ -67,7 +75,7 @@ class LossComputer:
         return loss * loss_weight
 
 
-class TrainTaskOperator:
+class TrainTaskOperator(typing.Generic[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState]):
     """Orchestrates the forward and backward passes for a training task over one pack.
 
     It builds the per-microbatch inputs, reconfigures the pipeline schedule for the pack length, and
@@ -77,9 +85,9 @@ class TrainTaskOperator:
     def __init__(
         self,
         dist_context: DistributedContext,
-        task: TrainTask,
-        pipeline: PipelineScheduleInfo,
-        pipeline_state: PipelineStateHandler,
+        task: TrainTask[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState],
+        pipeline: PipelineScheduleInfo[TPipelineInput, TSharedInput, TPipelineOutput],
+        pipeline_state: PipelineStateHandler[TState],
         gradient_manager: GradientManager,
         job_schedule: JobSchedule,
         metrics: ComposeMetric,
@@ -103,20 +111,20 @@ class TrainTaskOperator:
         self._job_schedule = job_schedule
         self._metrics = metrics
 
-    def forward_backward(self, pack: MicrobatchPack) -> None:
+    def forward_backward(self, pack: MicrobatchPack[TBatch]) -> None:
         """Executes the forward and backward passes for one pack of microbatches.
 
         Args:
             pack: The step's pack of raw microbatches.
         """
         try:
-            inputs_microbatches, kwargs_microbatches = build_pipeline_microbatch_inputs(
+            inputs_microbatches, shared_microbatches = build_pipeline_microbatch_inputs(
                 self._task, self._pipeline_state, pack
             )
             self._gradient_manager.set_required_accumulations(len(pack))
             self._pipeline.schedule.step(
                 inputs_microbatches=inputs_microbatches,
-                kwargs_microbatches=kwargs_microbatches,
+                shared_microbatches=shared_microbatches,
                 callback=LossComputer(
                     state=self._pipeline_state,
                     task=self._task,

--- a/d9d/loop/control/task.py
+++ b/d9d/loop/control/task.py
@@ -18,6 +18,9 @@ if typing.TYPE_CHECKING:
 
 TBatch = typing.TypeVar("TBatch", bound=PyTree)
 TState = typing.TypeVar("TState", bound=PyTree)
+TPipelineInput = typing.TypeVar("TPipelineInput")
+TSharedInput = typing.TypeVar("TSharedInput")
+TPipelineOutput = typing.TypeVar("TPipelineOutput")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -32,19 +35,19 @@ class BuildForwardInputsContext(typing.Generic[TBatch]):
 
 
 @dataclasses.dataclass(kw_only=True)
-class BuildForwardInputsResult(typing.Generic[TState]):
+class BuildForwardInputsResult(typing.Generic[TPipelineInput, TSharedInput, TState]):
     """The result of processing one raw microbatch into model inputs.
 
     Attributes:
-        inputs: A dictionary of inputs that are passed to model pipeline as input data
+        input: The ``PipelineInput`` passed to the model pipeline as input data
             (first stage only if using pipeline parallelism).
-        kwargs: A dictionary of keyword arguments passed to each pipeline stage.
+        shared: The ``SharedInput`` passed to every pipeline stage.
         state: Side-data (a PyTree, e.g. a TypedDict) carried to loss/output processing for this same
             microbatch — labels, masks, anything the model forward does not return but the loss needs.
     """
 
-    inputs: dict[str, torch.Tensor]
-    kwargs: dict[str, Any]
+    input: TPipelineInput
+    shared: TSharedInput
     state: TState
 
 
@@ -66,17 +69,21 @@ class FinalizeContext:
     """Context data provided when the task is being finalized."""
 
 
-class BaseTask(abc.ABC, Stateful, typing.Generic[TBatch, TState]):
+class BaseTask(abc.ABC, Stateful, typing.Generic[TBatch, TPipelineInput, TSharedInput, TState]):
     """Abstract base class representing a unit of work (Task) in the training/inference loop.
 
     Type parameters:
         TBatch: The raw microbatch type produced by the data stream.
+        TPipelineInput: The ``PipelineInput`` fed to the first pipeline stage.
+        TSharedInput: The ``SharedInput`` fed to every pipeline stage.
         TState: The per-microbatch side-data carried from input building to loss/output processing.
             Tasks that carry nothing use ``None``.
     """
 
     @abc.abstractmethod
-    def build_forward_inputs(self, ctx: BuildForwardInputsContext[TBatch]) -> BuildForwardInputsResult[TState]:
+    def build_forward_inputs(
+        self, ctx: BuildForwardInputsContext[TBatch]
+    ) -> BuildForwardInputsResult[TPipelineInput, TSharedInput, TState]:
         """Transforms one raw microbatch into arguments for the model.
 
         Called once per microbatch in the step's pack.
@@ -122,16 +129,16 @@ class BaseTask(abc.ABC, Stateful, typing.Generic[TBatch, TState]):
 
 
 @dataclasses.dataclass(kw_only=True)
-class ComputeLossContext(typing.Generic[TState]):
+class ComputeLossContext(typing.Generic[TPipelineOutput, TState]):
     """Context data provided to calculate the loss during training.
 
     Attributes:
-        pipeline_results: The outputs returned by the model's forward pass.
+        pipeline_results: The ``PipelineOutput`` returned by the model's forward pass.
         state: The side-data this microbatch's ``build_forward_inputs`` returned.
         schedule: Component tracking the current step.
     """
 
-    pipeline_results: Mapping[str, torch.Tensor]
+    pipeline_results: TPipelineOutput
     state: TState
     schedule: "JobSchedule"
 
@@ -179,11 +186,15 @@ class UpdateMetricsContext(typing.Generic[TState]):
     metrics: Mapping[str, "Metric"]
 
 
-class TrainTask(BaseTask[TBatch, TState], abc.ABC, typing.Generic[TBatch, TState]):
+class TrainTask(
+    BaseTask[TBatch, TPipelineInput, TSharedInput, TState],
+    abc.ABC,
+    typing.Generic[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState],
+):
     """Abstract base class for defining training-specific logic."""
 
     @abc.abstractmethod
-    def compute_loss(self, ctx: ComputeLossContext[TState]) -> ComputeLossResult:
+    def compute_loss(self, ctx: ComputeLossContext[TPipelineOutput, TState]) -> ComputeLossResult:
         """Calculates the loss based on model outputs.
 
         Args:
@@ -249,23 +260,27 @@ class TrainTaskProvider(Protocol):
 
 
 @dataclasses.dataclass(kw_only=True)
-class ProcessOutputsContext(typing.Generic[TState]):
+class ProcessOutputsContext(typing.Generic[TPipelineOutput, TState]):
     """Context data provided to process outputs during inference.
 
     Attributes:
-        pipeline_results: The outputs returned by the model's forward pass.
+        pipeline_results: The ``PipelineOutput`` returned by the model's forward pass.
         state: The side-data this microbatch's ``build_forward_inputs`` returned.
     """
 
-    pipeline_results: dict[str, torch.Tensor]
+    pipeline_results: TPipelineOutput
     state: TState
 
 
-class InferenceTask(BaseTask[TBatch, TState], abc.ABC, typing.Generic[TBatch, TState]):
+class InferenceTask(
+    BaseTask[TBatch, TPipelineInput, TSharedInput, TState],
+    abc.ABC,
+    typing.Generic[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState],
+):
     """Abstract base class for defining inference-specific logic."""
 
     @abc.abstractmethod
-    def process_outputs(self, ctx: ProcessOutputsContext[TState]):
+    def process_outputs(self, ctx: ProcessOutputsContext[TPipelineOutput, TState]):
         """Processes the model outputs (e.g. saving to disk, decoding tokens).
 
         Args:

--- a/d9d/module/model/io/__init__.py
+++ b/d9d/module/model/io/__init__.py
@@ -1,0 +1,23 @@
+"""Typed pipeline IO dataclasses for the model catalogue."""
+
+from .sequence import (
+    SequenceCausalLMOutput,
+    SequenceCausalLMShared,
+    SequenceClassificationOutput,
+    SequenceEmbeddingOutput,
+    SequenceInput,
+    SequencePoolingShared,
+    SequenceShared,
+    SequenceTransfer,
+)
+
+__all__ = [
+    "SequenceCausalLMOutput",
+    "SequenceCausalLMShared",
+    "SequenceClassificationOutput",
+    "SequenceEmbeddingOutput",
+    "SequenceInput",
+    "SequencePoolingShared",
+    "SequenceShared",
+    "SequenceTransfer",
+]

--- a/d9d/module/model/io/sequence.py
+++ b/d9d/module/model/io/sequence.py
@@ -1,0 +1,106 @@
+import dataclasses
+from typing import Generic, TypeVar
+
+import torch
+
+TLeaf = TypeVar("TLeaf")
+
+
+@dataclasses.dataclass
+class SequenceInput:
+    """The inputs for a sequence transformer: the token ids fed to the first stage.
+
+    Attributes:
+        input_ids: Indices of input sequence tokens, shape ``[batch, seq]``.
+    """
+
+    input_ids: torch.Tensor
+
+
+@dataclasses.dataclass
+class SequenceTransfer(Generic[TLeaf]):
+    """The object moved between adjacent stages of a sequence transformer.
+
+    Attributes:
+        hidden_states: The output of the last layer of the sending stage, shape ``[batch, seq, hidden]``.
+        hidden_states_snapshot: The accumulated aggregated hidden states carried across stages when
+            snapshotting is enabled, else ``None``.
+    """
+
+    hidden_states: TLeaf
+    hidden_states_snapshot: TLeaf | None = None
+
+
+@dataclasses.dataclass
+class SequenceShared:
+    """The shared input the transformer backbone consumes on every stage.
+
+    Attributes:
+        position_ids: Indices of positions of each token in the position embeddings.
+        hidden_states_agg_mask: Mask used to aggregate hidden states for snapshots, if enabled.
+    """
+
+    position_ids: torch.Tensor
+    hidden_states_agg_mask: torch.Tensor | None = None
+
+
+@dataclasses.dataclass
+class SequenceCausalLMShared:
+    """The shared input for causal language modeling, broadcast to every stage.
+
+    Attributes:
+        sequence: The backbone shared input.
+        labels: Target tokens for the loss computation (used on the last stage).
+    """
+
+    sequence: SequenceShared
+    labels: torch.Tensor | None = None
+
+
+@dataclasses.dataclass
+class SequencePoolingShared:
+    """The shared input for pooled heads (classification/embedding), broadcast to every stage.
+
+    Attributes:
+        sequence: The backbone shared input.
+        pooling_mask: Binary mask indicating which token(s) to pool (used on the last stage). You can
+            use ``d9d.dataset.token_pooling_mask_from_attention_mask`` to build it from an attention mask.
+    """
+
+    sequence: SequenceShared
+    pooling_mask: torch.Tensor | None = None
+
+
+@dataclasses.dataclass
+class SequenceCausalLMOutput:
+    """The output of a causal language modeling head.
+
+    Attributes:
+        logps: Per-token log-probabilities / loss, shape ``[batch, seq]``.
+    """
+
+    logps: torch.Tensor
+
+
+@dataclasses.dataclass
+class SequenceClassificationOutput:
+    """The output of a classification head.
+
+    Attributes:
+        scores: Classification logits, shape ``[num_pooled_tokens, num_labels]`` when a pooling mask
+            selects tokens, or ``[batch, seq, num_labels]`` when no pooling mask is used.
+    """
+
+    scores: torch.Tensor
+
+
+@dataclasses.dataclass
+class SequenceEmbeddingOutput:
+    """The output of an embedding head.
+
+    Attributes:
+        embeddings: Pooled embeddings, shape ``[num_pooled_tokens, embedding_dim]`` when a pooling mask
+            selects tokens, or ``[batch, seq, embedding_dim]`` when no pooling mask is used.
+    """
+
+    embeddings: torch.Tensor

--- a/d9d/module/model/qwen3_dense/model.py
+++ b/d9d/module/model/qwen3_dense/model.py
@@ -12,9 +12,20 @@ from d9d.module.block.head import ClassificationHead, EmbeddingHead, SplitLangua
 from d9d.module.block.hidden_states_aggregator import HiddenStatesAggregationMode, create_hidden_states_aggregator
 from d9d.module.block.normalization import RMSNorm
 from d9d.module.block.positional import RotaryEmbeddingProvider, RotaryEmbeddingStyle
+from d9d.module.model.io import (
+    SequenceCausalLMOutput,
+    SequenceCausalLMShared,
+    SequenceClassificationOutput,
+    SequenceEmbeddingOutput,
+    SequenceInput,
+    SequencePoolingShared,
+    SequenceShared,
+    SequenceTransfer,
+)
 from d9d.pipelining.api import (
     ModuleSupportsPipelining,
     PipelineStageInfo,
+    StageBoundary,
     distribute_layers_for_pipeline_stage,
 )
 
@@ -27,7 +38,13 @@ from .params import (
 )
 
 
-class Qwen3DenseModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3DenseModel(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequenceShared, SequenceTransfer[torch.Tensor]
+    ],
+):
     """The Qwen3 Dense Transformer Decoder backbone.
 
     It is designed to be split across multiple pipeline stages.
@@ -98,40 +115,35 @@ class Qwen3DenseModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor | None]:
-        """Executes the forward pass for the current pipeline stage.
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequenceShared,
+    ) -> SequenceTransfer[torch.Tensor]:
+        """Executes the backbone forward pass for the current pipeline stage.
 
         Args:
-            input_ids: Indices of input sequence tokens. Required if this is the
-                first pipeline stage.
-            hidden_states: Hidden states from the previous pipeline stage. Required
-                if this is not the first pipeline stage.
-            position_ids: Indices of positions of each input sequence tokens in the
-                position embeddings.
-            hidden_states_snapshot: Accumulated tensor of aggregated hidden states
-                from previous stages. Used if snapshotting is enabled.
-            hidden_states_agg_mask: Mask used to aggregate hidden states for
-                snapshots.
+            inputs: ``SequenceInput`` (token ids) on the first stage; the incoming
+                ``SequenceTransfer`` otherwise.
+            shared: The backbone shared input (position ids and, if snapshotting is enabled, the
+                aggregation mask).
 
         Returns:
-            A dictionary containing:
-                *   'hidden_states': The output of the last layer in this stage.
-                *   'hidden_states_snapshot': (Optional) The updated snapshot tensor.
+            The produced ``SequenceTransfer`` (hidden states and, optionally, the updated snapshot).
         """
-        state_aggregator = create_hidden_states_aggregator(self._hidden_states_snapshot_mode, hidden_states_agg_mask)
+        state_aggregator = create_hidden_states_aggregator(
+            self._hidden_states_snapshot_mode, shared.hidden_states_agg_mask
+        )
 
-        if input_ids is not None:
-            last_hidden_states = self.embed_tokens(input_ids)
+        if self._stage.is_current_stage_first:
+            first_inputs = cast(SequenceInput, inputs)
+            last_hidden_states = self.embed_tokens(first_inputs.input_ids)
+            hidden_states_snapshot = None
             state_aggregator.add_hidden_states(last_hidden_states)
         else:
-            last_hidden_states = hidden_states
+            transfer_inputs = cast(SequenceTransfer[torch.Tensor], inputs)
+            last_hidden_states = transfer_inputs.hidden_states
+            hidden_states_snapshot = transfer_inputs.hidden_states_snapshot
 
-        rope_params = self.rope_provider(position_ids)
+        rope_params = self.rope_provider(shared.position_ids)
 
         for decoder_layer_name in self._layers_iter:
             decoder_layer = self.layers[decoder_layer_name]
@@ -146,10 +158,10 @@ class Qwen3DenseModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             last_hidden_states = self.norm(last_hidden_states)
 
-        return {
-            "hidden_states": last_hidden_states,
-            "hidden_states_snapshot": state_aggregator.pack_with_snapshot(hidden_states_snapshot),
-        }
+        return SequenceTransfer(
+            hidden_states=last_hidden_states,
+            hidden_states_snapshot=state_aggregator.pack_with_snapshot(hidden_states_snapshot),
+        )
 
     def reset_parameters(self):
         """Resets module parameters."""
@@ -165,51 +177,42 @@ class Qwen3DenseModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             self.norm.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        input_ids = microbatch_inputs["input_ids"]
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        """Describes the ``SequenceTransfer`` crossing the given boundary of this stage.
 
-        pp_inputs = {}
+        Args:
+            pipeline_input: A representative ``SequenceInput`` microbatch; only shapes are read.
+            boundary: Which inter-stage edge to describe.
 
-        # for calculation - input ids or prev hidden state
-        if self._stage.is_current_stage_first:
-            pp_inputs["input_ids"] = TensorSpec(shape=(input_ids.shape[0], input_ids.shape[1]), dtype=torch.long)
-        else:
-            pp_inputs["hidden_states"] = TensorSpec(
-                shape=(input_ids.shape[0], input_ids.shape[1], self._hidden_size), dtype=self.output_dtype()
-            )
-            if self._hidden_states_snapshot_mode != HiddenStatesAggregationMode.no:
-                num_layers_before = self._num_layers_before + 1  # 1 for embedding
-                pp_inputs["hidden_states_snapshot"] = TensorSpec(
-                    shape=(num_layers_before, input_ids.shape[0], self._hidden_size), dtype=self.output_dtype()
-                )
+        Returns:
+            A ``SequenceTransfer`` of ``TensorSpec``.
+        """
+        batch, seq = pipeline_input.input_ids.shape[0], pipeline_input.input_ids.shape[1]
 
-        return pp_inputs
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        input_ids = microbatch_inputs["input_ids"]
-
-        pp_outputs = {
-            "hidden_states": TensorSpec(
-                shape=(input_ids.shape[0], input_ids.shape[1], self._hidden_size), dtype=self.output_dtype()
-            )
-        }
-
+        snapshot_spec = None
         if self._hidden_states_snapshot_mode != HiddenStatesAggregationMode.no:
-            num_layers_before = self._num_layers_before + 1
-            num_layers_current = len(self.layers)
-            num_layers_after = num_layers_before + num_layers_current
-            pp_outputs["hidden_states_snapshot"] = TensorSpec(
-                shape=(num_layers_after, input_ids.shape[0], self._hidden_size), dtype=self.output_dtype()
-            )
+            num_layers_before = self._num_layers_before + 1  # 1 for embedding
+            if boundary is StageBoundary.outgoing:
+                num_layers = num_layers_before + len(self.layers)
+            else:
+                num_layers = num_layers_before
+            snapshot_spec = TensorSpec(shape=(num_layers, batch, self._hidden_size), dtype=self.output_dtype())
 
-        return pp_outputs
+        return SequenceTransfer(
+            hidden_states=TensorSpec(shape=(batch, seq, self._hidden_size), dtype=self.output_dtype()),
+            hidden_states_snapshot=snapshot_spec,
+        )
 
 
-class Qwen3DenseForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3DenseForCausalLM(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequenceCausalLMShared, SequenceCausalLMOutput
+    ],
+):
     """A Qwen3 Dense model wrapped with a Causal Language Modeling head.
 
     It is designed to be split across multiple pipeline stages.
@@ -251,40 +254,27 @@ class Qwen3DenseForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining)
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        labels: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequenceCausalLMShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceCausalLMOutput:
         """Executes the model forward pass.
 
-        If this is the last stage, it expects `labels` to be provided and computes
-        the cross-entropy loss (returned as 'logps' typically representing per-token loss).
+        If this is the last stage, it expects ``shared.labels`` to be provided and computes the
+        cross-entropy loss (returned as per-token ``logps``).
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            labels: Target tokens for loss computation (Last Stage).
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, labels).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot',
-            and per-token 'logps' if on the last stage.
+            The produced ``SequenceTransfer`` on non-last stages, or the ``CausalLMOutput`` on the
+            last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            lm_out = self.lm_head(hidden_states=model_outputs["hidden_states"], labels=labels)
-            model_outputs["logps"] = lm_out
+            return SequenceCausalLMOutput(
+                logps=self.lm_head(hidden_states=model_outputs.hidden_states, labels=shared.labels)
+            )
         return model_outputs
 
     def reset_parameters(self):
@@ -294,23 +284,19 @@ class Qwen3DenseForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining)
         if self._stage.is_current_stage_last:
             self.lm_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            pp_outputs["logps"] = TensorSpec(shape=tuple(microbatch_inputs["input_ids"].shape), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)
 
 
-class Qwen3DenseForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3DenseForClassification(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequencePoolingShared, SequenceClassificationOutput
+    ],
+):
     """A Qwen3 Dense model wrapped with a Sequence/Token Classification head.
 
     It is designed to be split across multiple pipeline stages.
@@ -353,39 +339,23 @@ class Qwen3DenseForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipel
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        pooling_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequencePoolingShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceClassificationOutput:
         """Executes the classification model forward pass.
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            pooling_mask: Binary mask indicating which token(s) to pool for classification.
-                Note: you can use `d9d.dataset.token_pooling_mask_from_attention_mask`
-                in your Dataset to preallocate the pooling mask from attention mask.
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, pooling mask).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot'.
-                If on the last stage, also contains 'scores' (logits) of shape [batch, num_labels].
+            The produced ``SequenceTransfer`` on non-last stages, or the ``ClassificationOutput`` on
+            the last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            model_outputs["scores"] = self.cls_head(
-                hidden_states=model_outputs["hidden_states"], pooling_mask=pooling_mask
+            return SequenceClassificationOutput(
+                scores=self.cls_head(hidden_states=model_outputs.hidden_states, pooling_mask=shared.pooling_mask)
             )
         return model_outputs
 
@@ -396,24 +366,19 @@ class Qwen3DenseForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipel
         if self._stage.is_current_stage_last:
             self.cls_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            batch_size = microbatch_inputs["input_ids"].shape[0]
-            pp_outputs["scores"] = TensorSpec(shape=(batch_size, self._num_labels), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)
 
 
-class Qwen3DenseForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3DenseForEmbedding(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequencePoolingShared, SequenceEmbeddingOutput
+    ],
+):
     """A Qwen3 Dense model wrapped with an Embedding head.
 
     It is designed to be split across multiple pipeline stages.
@@ -457,37 +422,25 @@ class Qwen3DenseForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        pooling_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequencePoolingShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceEmbeddingOutput:
         """Executes the embedding model forward pass.
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            pooling_mask: Binary mask indicating which token(s) to pool for embedding extraction.
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, pooling mask).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot'.
-                If on the last stage, also contains 'embeddings'.
+            The produced ``SequenceTransfer`` on non-last stages, or the ``EmbeddingOutput`` on the
+            last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            model_outputs["embeddings"] = self.embedding_head(
-                hidden_states=model_outputs["hidden_states"], pooling_mask=pooling_mask
+            return SequenceEmbeddingOutput(
+                embeddings=self.embedding_head(
+                    hidden_states=model_outputs.hidden_states, pooling_mask=shared.pooling_mask
+                )
             )
         return model_outputs
 
@@ -498,18 +451,7 @@ class Qwen3DenseForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining
         if self._stage.is_current_stage_last:
             self.embedding_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            batch_size = microbatch_inputs["input_ids"].shape[0]
-            pp_outputs["embeddings"] = TensorSpec(shape=(batch_size, self._embedding_dim), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)

--- a/d9d/module/model/qwen3_moe/model.py
+++ b/d9d/module/model/qwen3_moe/model.py
@@ -12,9 +12,20 @@ from d9d.module.block.head import ClassificationHead, EmbeddingHead, SplitLangua
 from d9d.module.block.hidden_states_aggregator import HiddenStatesAggregationMode, create_hidden_states_aggregator
 from d9d.module.block.normalization import RMSNorm
 from d9d.module.block.positional import RotaryEmbeddingProvider, RotaryEmbeddingStyle
+from d9d.module.model.io import (
+    SequenceCausalLMOutput,
+    SequenceCausalLMShared,
+    SequenceClassificationOutput,
+    SequenceEmbeddingOutput,
+    SequenceInput,
+    SequencePoolingShared,
+    SequenceShared,
+    SequenceTransfer,
+)
 from d9d.pipelining.api import (
     ModuleSupportsPipelining,
     PipelineStageInfo,
+    StageBoundary,
     distribute_layers_for_pipeline_stage,
 )
 
@@ -27,7 +38,13 @@ from .params import (
 )
 
 
-class Qwen3MoEModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3MoEModel(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequenceShared, SequenceTransfer[torch.Tensor]
+    ],
+):
     """The Qwen3 Mixture-of-Experts (MoE) Transformer Decoder backbone.
 
     It is designed to be split across multiple pipeline stages.
@@ -96,40 +113,35 @@ class Qwen3MoEModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor | None]:
-        """Executes the forward pass for the current pipeline stage.
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequenceShared,
+    ) -> SequenceTransfer[torch.Tensor]:
+        """Executes the backbone forward pass for the current pipeline stage.
 
         Args:
-            input_ids: Indices of input sequence tokens. Required if this is the
-                first pipeline stage.
-            hidden_states: Hidden states from the previous pipeline stage. Required
-                if this is not the first pipeline stage.
-            position_ids: Indices of positions of each input sequence tokens in the
-                position embeddings.
-            hidden_states_snapshot: Accumulated tensor of aggregated hidden states
-                from previous stages. Used if snapshotting is enabled.
-            hidden_states_agg_mask: Mask used to aggregate hidden states for
-                snapshots.
+            inputs: ``SequenceInput`` (token ids) on the first stage; the incoming
+                ``SequenceTransfer`` otherwise.
+            shared: The shared input broadcast to every stage (position ids and, if snapshotting is
+                enabled, the aggregation mask).
 
         Returns:
-            A dictionary containing:
-                *   'hidden_states': The output of the last layer in this stage.
-                *   'hidden_states_snapshot': (Optional) The updated snapshot tensor.
+            The produced ``SequenceTransfer`` (hidden states and, optionally, the updated snapshot).
         """
-        state_aggregator = create_hidden_states_aggregator(self._hidden_states_snapshot_mode, hidden_states_agg_mask)
+        state_aggregator = create_hidden_states_aggregator(
+            self._hidden_states_snapshot_mode, shared.hidden_states_agg_mask
+        )
 
-        if input_ids is not None:
-            last_hidden_states = self.embed_tokens(input_ids)
+        if self._stage.is_current_stage_first:
+            first_inputs = cast(SequenceInput, inputs)
+            last_hidden_states = self.embed_tokens(first_inputs.input_ids)
+            hidden_states_snapshot = None
             state_aggregator.add_hidden_states(last_hidden_states)
         else:
-            last_hidden_states = hidden_states
+            transfer_inputs = cast(SequenceTransfer[torch.Tensor], inputs)
+            last_hidden_states = transfer_inputs.hidden_states
+            hidden_states_snapshot = transfer_inputs.hidden_states_snapshot
 
-        rope_params = self.rope_provider(position_ids)
+        rope_params = self.rope_provider(shared.position_ids)
 
         for decoder_layer_name in self._layers_iter:
             decoder_layer = self.layers[decoder_layer_name]
@@ -144,10 +156,10 @@ class Qwen3MoEModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             last_hidden_states = self.norm(last_hidden_states)
 
-        return {
-            "hidden_states": last_hidden_states,
-            "hidden_states_snapshot": state_aggregator.pack_with_snapshot(hidden_states_snapshot),
-        }
+        return SequenceTransfer(
+            hidden_states=last_hidden_states,
+            hidden_states_snapshot=state_aggregator.pack_with_snapshot(hidden_states_snapshot),
+        )
 
     def reset_parameters(self):
         """Resets module parameters."""
@@ -163,58 +175,42 @@ class Qwen3MoEModel(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             self.norm.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        input_ids = microbatch_inputs["input_ids"]
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        """Describes the ``SequenceTransfer`` crossing the given boundary of this stage.
 
-        pp_inputs = {}
+        Args:
+            pipeline_input: A representative ``SequenceInput`` microbatch; only shapes are read.
+            boundary: Which inter-stage edge to describe.
 
-        # for calculation - input ids or prev hidden state
-        if self._stage.is_current_stage_first:
-            pp_inputs["input_ids"] = TensorSpec(shape=(input_ids.shape[0], input_ids.shape[1]), dtype=torch.long)
-        else:
-            pp_inputs["hidden_states"] = TensorSpec(
-                shape=(input_ids.shape[0], input_ids.shape[1], self._hidden_size), dtype=self.output_dtype()
-            )
-            if self._hidden_states_snapshot_mode != HiddenStatesAggregationMode.no:
-                num_layers_before = self._num_layers_before + 1  # 1 for embedding
-                pp_inputs["hidden_states_snapshot"] = TensorSpec(
-                    shape=(num_layers_before, input_ids.shape[0], self._hidden_size), dtype=self.output_dtype()
-                )
+        Returns:
+            A ``SequenceTransfer`` of ``TensorSpec``.
+        """
+        batch, seq = pipeline_input.input_ids.shape[0], pipeline_input.input_ids.shape[1]
 
-        return pp_inputs
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        input_ids = microbatch_inputs["input_ids"]
-
-        # for calculation - last hidden state
-        pp_outputs = {
-            "hidden_states": TensorSpec(
-                shape=(input_ids.shape[0], input_ids.shape[1], self._hidden_size), dtype=self.output_dtype()
-            )
-        }
-
-        # for state caching
+        snapshot_spec = None
         if self._hidden_states_snapshot_mode != HiddenStatesAggregationMode.no:
-            num_layers_before = self._num_layers_before + 1
-            num_layers_current = len(self.layers)
-            num_layers_after = num_layers_before + num_layers_current
-            pp_outputs["hidden_states_snapshot"] = TensorSpec(
-                shape=(num_layers_after, input_ids.shape[0], self._hidden_size), dtype=self.output_dtype()
-            )
+            num_layers_before = self._num_layers_before + 1  # 1 for embedding
+            if boundary is StageBoundary.outgoing:
+                num_layers = num_layers_before + len(self.layers)
+            else:
+                num_layers = num_layers_before
+            snapshot_spec = TensorSpec(shape=(num_layers, batch, self._hidden_size), dtype=self.output_dtype())
 
-        return pp_outputs
+        return SequenceTransfer(
+            hidden_states=TensorSpec(shape=(batch, seq, self._hidden_size), dtype=self.output_dtype()),
+            hidden_states_snapshot=snapshot_spec,
+        )
 
 
-class Qwen3MoEForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
-    """A Qwen3 MoE model wrapped with a Causal Language Modeling head.
-
-    It is designed to be split across multiple pipeline stages.
-    """
-
+class Qwen3MoEForCausalLM(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequenceCausalLMShared, SequenceCausalLMOutput
+    ],
+):
     def __init__(
         self,
         params: Qwen3MoEForCausalLMParameters,
@@ -222,14 +218,6 @@ class Qwen3MoEForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         hidden_states_snapshot_mode: HiddenStatesAggregationMode,
         enable_checkpointing: bool,
     ):
-        """Constructs the Qwen3MoEForCausalLM object.
-
-        Args:
-            params: Full model configuration parameters.
-            stage: Pipeline stage information for this instance.
-            hidden_states_snapshot_mode: Configures intermediate hidden state aggregation & snapshotting mode.
-            enable_checkpointing: Whether to enable activation checkpointing.
-        """
         super().__init__()
 
         self.model = Qwen3MoEModel(
@@ -251,40 +239,27 @@ class Qwen3MoEForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        labels: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequenceCausalLMShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceCausalLMOutput:
         """Executes the model forward pass.
 
-        If this is the last stage, it expects `labels` to be provided and computes
-        the cross-entropy loss (returned as 'logps' typically representing per-token loss).
+        If this is the last stage, it expects ``shared.labels`` to be provided and computes the
+        cross-entropy loss (returned as per-token ``logps``).
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            labels: Target tokens for loss computation (Last Stage).
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, labels).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot',
-            and per-token 'logps' if on the last stage.
+            The produced ``SequenceTransfer`` on non-last stages, or the ``CausalLMOutput`` on the
+            last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            lm_out = self.lm_head(hidden_states=model_outputs["hidden_states"], labels=labels)
-            model_outputs["logps"] = lm_out
+            return SequenceCausalLMOutput(
+                logps=self.lm_head(hidden_states=model_outputs.hidden_states, labels=shared.labels)
+            )
         return model_outputs
 
     def reset_parameters(self):
@@ -294,23 +269,19 @@ class Qwen3MoEForCausalLM(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             self.lm_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            pp_outputs["logps"] = TensorSpec(shape=tuple(microbatch_inputs["input_ids"].shape), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)
 
 
-class Qwen3MoEForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3MoEForClassification(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequencePoolingShared, SequenceClassificationOutput
+    ],
+):
     """A Qwen3 MoE model wrapped with a Sequence/Token Classification head.
 
     It is designed to be split across multiple pipeline stages.
@@ -353,39 +324,23 @@ class Qwen3MoEForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipelin
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        pooling_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequencePoolingShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceClassificationOutput:
         """Executes the classification model forward pass.
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            pooling_mask: Binary mask indicating which token(s) to pool for classification.
-                Note: you can use `d9d.dataset.token_pooling_mask_from_attention_mask`
-                in your Dataset to preallocate the pooling mask from attention mask.
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, pooling mask).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot'.
-                If on the last stage, also contains 'scores' (logits) of shape [batch, num_labels].
+            The produced ``SequenceTransfer`` on non-last stages, or the ``ClassificationOutput`` on
+            the last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            model_outputs["scores"] = self.cls_head(
-                hidden_states=model_outputs["hidden_states"], pooling_mask=pooling_mask
+            return SequenceClassificationOutput(
+                scores=self.cls_head(hidden_states=model_outputs.hidden_states, pooling_mask=shared.pooling_mask)
             )
         return model_outputs
 
@@ -396,24 +351,19 @@ class Qwen3MoEForClassification(nn.Module, ModuleLateInit, ModuleSupportsPipelin
         if self._stage.is_current_stage_last:
             self.cls_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            batch_size = microbatch_inputs["input_ids"].shape[0]
-            pp_outputs["scores"] = TensorSpec(shape=(batch_size, self._num_labels), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)
 
 
-class Qwen3MoEForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
+class Qwen3MoEForEmbedding(
+    nn.Module,
+    ModuleLateInit,
+    ModuleSupportsPipelining[
+        SequenceInput, SequenceTransfer[torch.Tensor], SequencePoolingShared, SequenceEmbeddingOutput
+    ],
+):
     """A Qwen3 MoE model wrapped with an Embedding head.
 
     It is designed to be split across multiple pipeline stages.
@@ -457,37 +407,25 @@ class Qwen3MoEForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
 
     def forward(
         self,
-        input_ids: torch.Tensor | None = None,
-        hidden_states: torch.Tensor | None = None,
-        position_ids: torch.Tensor | None = None,
-        hidden_states_snapshot: torch.Tensor | None = None,
-        hidden_states_agg_mask: torch.Tensor | None = None,
-        pooling_mask: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
+        inputs: SequenceInput | SequenceTransfer[torch.Tensor],
+        shared: SequencePoolingShared,
+    ) -> SequenceTransfer[torch.Tensor] | SequenceEmbeddingOutput:
         """Executes the embedding model forward pass.
 
         Args:
-            input_ids: Input token IDS (for Stage 0).
-            hidden_states: Hidden states from previous stage (for Stage > 0).
-            position_ids: Positional indices for RoPE.
-            hidden_states_snapshot: Intermediate state collector.
-            hidden_states_agg_mask: Mask for state aggregation.
-            pooling_mask: Binary mask indicating which token(s) to pool for embedding extraction.
+            inputs: ``SequenceInput`` on the first stage; incoming ``SequenceTransfer`` otherwise.
+            shared: The shared input (position ids, aggregation mask, pooling mask).
 
         Returns:
-            Dictionary containing 'hidden_states', optionally 'hidden_states_snapshot'.
-                If on the last stage, also contains 'embeddings'.
+            The produced ``SequenceTransfer`` on non-last stages, or the ``EmbeddingOutput`` on the
+            last stage.
         """
-        model_outputs = self.model(
-            input_ids=input_ids,
-            hidden_states=hidden_states,
-            position_ids=position_ids,
-            hidden_states_snapshot=hidden_states_snapshot,
-            hidden_states_agg_mask=hidden_states_agg_mask,
-        )
+        model_outputs = self.model(inputs, shared.sequence)
         if self._stage.is_current_stage_last:
-            model_outputs["embeddings"] = self.embedding_head(
-                hidden_states=model_outputs["hidden_states"], pooling_mask=pooling_mask
+            return SequenceEmbeddingOutput(
+                embeddings=self.embedding_head(
+                    hidden_states=model_outputs.hidden_states, pooling_mask=shared.pooling_mask
+                )
             )
         return model_outputs
 
@@ -498,18 +436,7 @@ class Qwen3MoEForEmbedding(nn.Module, ModuleLateInit, ModuleSupportsPipelining):
         if self._stage.is_current_stage_last:
             self.embedding_head.reset_parameters()
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return self.model.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs)
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        pp_outputs = self.model.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs)
-
-        if self._stage.is_current_stage_last:
-            batch_size = microbatch_inputs["input_ids"].shape[0]
-            pp_outputs["embeddings"] = TensorSpec(shape=(batch_size, self._embedding_dim), dtype=torch.float32)
-
-        return pp_outputs
+    def stage_transfer_spec(
+        self, pipeline_input: SequenceInput, boundary: StageBoundary
+    ) -> SequenceTransfer[TensorSpec]:
+        return self.model.stage_transfer_spec(pipeline_input, boundary)

--- a/d9d/pipelining/api/__init__.py
+++ b/d9d/pipelining/api/__init__.py
@@ -8,7 +8,14 @@ from .module import (
     distribute_layers_for_pipeline_stage,
 )
 from .schedule import PipelineSchedule
-from .types import PipelineLossFn, PipelineResultFn
+from .types import (
+    PipelineLossFn,
+    PipelineResultFn,
+    TPipelineInput,
+    TPipelineOutput,
+    TSharedInput,
+    TStageTransfer,
+)
 
 __all__ = [
     "ModuleSupportsPipelining",
@@ -17,6 +24,10 @@ __all__ = [
     "PipelineSchedule",
     "PipelineStageInfo",
     "StageBoundary",
+    "TPipelineInput",
+    "TPipelineOutput",
+    "TSharedInput",
+    "TStageTransfer",
     "TensorSpec",
     "distribute_layers_for_pipeline_stage",
 ]

--- a/d9d/pipelining/api/__init__.py
+++ b/d9d/pipelining/api/__init__.py
@@ -3,6 +3,7 @@
 from .module import (
     ModuleSupportsPipelining,
     PipelineStageInfo,
+    StageBoundary,
     TensorSpec,
     distribute_layers_for_pipeline_stage,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "PipelineResultFn",
     "PipelineSchedule",
     "PipelineStageInfo",
+    "StageBoundary",
     "TensorSpec",
     "distribute_layers_for_pipeline_stage",
 ]

--- a/d9d/pipelining/api/module.py
+++ b/d9d/pipelining/api/module.py
@@ -145,12 +145,17 @@ class ModuleSupportsPipelining(typing.Protocol[TPipelineInput, TStageTransfer, T
         """
         ...
 
-    def stage_transfer_spec(self, pipeline_input: TPipelineInput, boundary: StageBoundary) -> PyTree[TensorSpec] | None:
+    def stage_transfer_spec(self, pipeline_input: TPipelineInput, boundary: StageBoundary) -> PyTree[TensorSpec]:
         """Describes the ``StageTransfer`` crossing the given boundary of this stage.
 
         The returned PyTree is structurally identical to the ``StageTransfer`` itself, with every
         tensor leaf replaced by its ``TensorSpec``. Shapes are derived by cheap arithmetic on
         ``pipeline_input``; the ``forward`` body is never executed.
+
+        The engine only calls this for boundaries that actually transfer, deciding terminality from
+        the pipeline topology — it is never called for the first stage's ``incoming`` edge nor the
+        last stage's ``outgoing`` edge. Implementations therefore do not need to special-case terminal
+        boundaries.
 
         Args:
             pipeline_input: A representative single microbatch of pipeline input. Only shapes and
@@ -159,7 +164,6 @@ class ModuleSupportsPipelining(typing.Protocol[TPipelineInput, TStageTransfer, T
                 next stage).
 
         Returns:
-            A PyTree of ``TensorSpec`` for the transfer crossing that boundary, or ``None`` when the
-            boundary is terminal (``incoming`` on the first stage, ``outgoing`` on the last stage).
+            A PyTree of ``TensorSpec`` for the transfer crossing that boundary.
         """
         ...

--- a/d9d/pipelining/api/module.py
+++ b/d9d/pipelining/api/module.py
@@ -1,9 +1,10 @@
 import dataclasses
+import enum
 import typing
 
-import torch
+from d9d.core.types import PyTree, TensorSpec
 
-from d9d.core.types import TensorSpec
+from .types import TPipelineInput, TPipelineOutput, TSharedInput, TStageTransfer
 
 
 @dataclasses.dataclass
@@ -100,39 +101,65 @@ def distribute_layers_for_pipeline_stage(
     return start_layer_id, start_layer_id + num_layers_in_stage
 
 
-@typing.runtime_checkable
-class ModuleSupportsPipelining(typing.Protocol):
-    """Protocol for modules that support pipeline parallelism metadata inference.
+class StageBoundary(enum.Enum):
+    """Identifies which inter-stage edge of a stage a transfer spec describes.
 
-    Classes implementing this protocol enable the framework to pre-calculate
-    tensor shapes and types required for inter-stage communication (p2p)
-    without executing the full forward pass.
+    Attributes:
+        incoming: The ``StageTransfer`` this stage receives from the previous stage.
+        outgoing: The ``StageTransfer`` this stage sends to the next stage.
     """
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        """Infers the input tensor specs for the current pipeline stage from a single microbatch.
+    incoming = "incoming"
+    outgoing = "outgoing"
+
+
+@typing.runtime_checkable
+class ModuleSupportsPipelining(typing.Protocol[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
+    """Protocol for modules that can be split across pipeline stages.
+
+    A pipelined module carries four distinct IO roles, each an arbitrary PyTree (dataclasses are the
+    recommended form). The module knows its position from the ``PipelineStageInfo`` it receives at
+    construction and branches on it explicitly.
+
+    Type parameters:
+        TPipelineInput: Input consumed by the *first* stage.
+        TStageTransfer: Payload transferred between adjacent stages. The outgoing transfer of stage
+            ``N`` and the incoming transfer of stage ``N+1`` are the *same* type.
+        TSharedInput: Value passed to *every* stage's forward.
+        TPipelineOutput: Output produced by the *last* stage.
+    """
+
+    def forward(
+        self,
+        inputs: TPipelineInput | TStageTransfer,
+        shared: TSharedInput,
+    ) -> TStageTransfer | TPipelineOutput:
+        """Runs this stage.
 
         Args:
-            microbatch_inputs: A representative single microbatch of pipeline inputs. Shapes are taken
-                as-is; there is no global batch to divide.
+            inputs: ``PipelineInput`` on the first stage; ``StageTransfer`` otherwise.
+            shared: The value broadcast to every stage.
 
         Returns:
-            Dictionary of input tensor specs expected by this specific stage locally.
+            ``PipelineOutput`` on the last stage; ``StageTransfer`` otherwise.
         """
         ...
 
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        """Infers the output tensor specs for the current pipeline stage from a single microbatch.
+    def stage_transfer_spec(self, pipeline_input: TPipelineInput, boundary: StageBoundary) -> PyTree[TensorSpec] | None:
+        """Describes the ``StageTransfer`` crossing the given boundary of this stage.
+
+        The returned PyTree is structurally identical to the ``StageTransfer`` itself, with every
+        tensor leaf replaced by its ``TensorSpec``. Shapes are derived by cheap arithmetic on
+        ``pipeline_input``; the ``forward`` body is never executed.
 
         Args:
-            microbatch_inputs: A representative single microbatch of pipeline inputs. Shapes are taken
-                as-is; there is no global batch to divide.
+            pipeline_input: A representative single microbatch of pipeline input. Only shapes and
+                dtypes are read; values are never used.
+            boundary: ``incoming`` (received from the previous stage) or ``outgoing`` (sent to the
+                next stage).
 
         Returns:
-            Dictionary of output tensor specs produced by this specific stage locally.
+            A PyTree of ``TensorSpec`` for the transfer crossing that boundary, or ``None`` when the
+            boundary is terminal (``incoming`` on the first stage, ``outgoing`` on the last stage).
         """
         ...

--- a/d9d/pipelining/api/schedule.py
+++ b/d9d/pipelining/api/schedule.py
@@ -1,34 +1,39 @@
 import abc
-from typing import Any
+import typing
 
-import torch
+from .types import (
+    PipelineLossFn,
+    PipelineResultFn,
+    TPipelineInput,
+    TPipelineOutput,
+    TSharedInput,
+)
 
-from .types import PipelineLossFn, PipelineResultFn
 
-# TODO: feature - support any PyTrees as pipeline parameters
+class PipelineSchedule(abc.ABC, typing.Generic[TPipelineInput, TSharedInput, TPipelineOutput]):
+    """Abstract base class defining the interface for pipeline execution schedules.
 
-
-class PipelineSchedule(abc.ABC):
-    """Abstract base class defining the interface for pipeline execution schedules."""
+    Type parameters:
+        TPipelineInput: The ``PipelineInput`` fed to the first stage.
+        TSharedInput: The ``SharedInput`` fed to every stage.
+        TPipelineOutput: The ``PipelineOutput`` produced by the last stage and handed to the output processing callback.
+    """
 
     @abc.abstractmethod
     def step(
         self,
-        inputs_microbatches: tuple[dict[str, torch.Tensor], ...],
-        kwargs_microbatches: tuple[dict[str, Any], ...],
-        callback: PipelineLossFn | PipelineResultFn,
+        inputs_microbatches: tuple[TPipelineInput, ...],
+        shared_microbatches: tuple[TSharedInput, ...],
+        callback: PipelineLossFn[TPipelineOutput] | PipelineResultFn[TPipelineOutput],
     ):
         """Executes a single pipeline step over one pack of microbatches.
 
-        The schedule receives the microbatches already split: ``inputs_microbatches[i]`` and
-        ``kwargs_microbatches[i]`` are the inputs and keyword arguments of the ``i``-th microbatch.
-        The number of microbatches in the step is ``len(inputs_microbatches)`` and may vary between
-        steps. Program compilation and buffer allocation happen lazily inside this call, reused across
-        steps when the microbatch count and shapes are unchanged.
+        The schedule receives the microbatches.
+        The number of microbatches in the step is ``len(inputs_microbatches)`` and may vary between steps.
 
         Args:
-            inputs_microbatches: Per-microbatch input tensors (fed to the first pipeline stage).
-            kwargs_microbatches: Per-microbatch keyword arguments (fed to every pipeline stage).
+            inputs_microbatches: Per-microbatch ``PipelineInput`` (fed to the first pipeline stage).
+            shared_microbatches: Per-microbatch ``SharedInput`` (fed to every pipeline stage).
             callback: Function to compute loss or process pipeline results.
         """
         ...

--- a/d9d/pipelining/api/types.py
+++ b/d9d/pipelining/api/types.py
@@ -1,26 +1,30 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeVar
 
 import torch
 
-PipelineResultFn = Callable[[dict[str, torch.Tensor], int], Any]
-"""
-Callback function type for handling results from a final pipeline stage.
+TPipelineInput = TypeVar("TPipelineInput")
+TStageTransfer = TypeVar("TStageTransfer")
+TSharedInput = TypeVar("TSharedInput")
+TPipelineOutput = TypeVar("TPipelineOutput")
+
+
+PipelineResultFn = Callable[[TPipelineOutput, int], Any]
+"""Callback function type for handling results from a final pipeline stage.
 
 Args:
-    outputs: A dictionary mapping output names to tensors produced by the stage.
+    outputs: The ``PipelineOutput`` produced by the last stage.
     microbatch_idx: The index of the current micro-batch being processed.
 
 Returns:
     Anything - not used.
 """
 
-PipelineLossFn = Callable[[dict[str, torch.Tensor], int], torch.Tensor]
-"""
-Callback function type for calculating loss in the final pipeline stage.
+PipelineLossFn = Callable[[TPipelineOutput, int], torch.Tensor]
+"""Callback function type for calculating loss in the final pipeline stage.
 
 Args:
-    outputs: A dictionary mapping output names to tensors produced by the model.
+    outputs: The ``PipelineOutput`` PyTree produced by the last stage.
     microbatch_idx: The index of the current micro-batch being processed.
 
 Returns:

--- a/d9d/pipelining/factory/factory.py
+++ b/d9d/pipelining/factory/factory.py
@@ -1,10 +1,12 @@
 import dataclasses
+import typing
 from collections.abc import Callable
 
 from torch import nn
 
 from ...core.dist_context import REGULAR_DOMAIN, DistributedContext
 from ..api import PipelineSchedule, PipelineStageInfo
+from ..api.types import TPipelineInput, TPipelineOutput, TSharedInput
 from ..infra.schedule.component.program import (
     build_stage_to_host_rank_topology,
     invert_stage_to_host_rank_topology,
@@ -19,10 +21,10 @@ from .registry import PIPELINE_PROGRAM_REGISTRY
 
 
 @dataclasses.dataclass(kw_only=True)
-class PipelineScheduleInfo:
+class PipelineScheduleInfo(typing.Generic[TPipelineInput, TSharedInput, TPipelineOutput]):
     """Contains the built pipeline schedule and rank-specific metadata."""
 
-    schedule: PipelineSchedule
+    schedule: PipelineSchedule[TPipelineInput, TSharedInput, TPipelineOutput]
     has_first_stage: bool
     has_last_stage: bool
 

--- a/d9d/pipelining/infra/schedule/component/runtime/action.py
+++ b/d9d/pipelining/infra/schedule/component/runtime/action.py
@@ -1,10 +1,9 @@
 import abc
 import dataclasses
 from enum import StrEnum
-from typing import Any
+from typing import Generic
 
-import torch
-
+from d9d.pipelining.api import TPipelineInput, TPipelineOutput, TSharedInput, TStageTransfer
 from d9d.pipelining.infra.stage import PipelineStage
 
 from .callback import PipelineLossHandler, PipelineResultHandler
@@ -12,23 +11,23 @@ from .communications import PipelineCommunicationHandler
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class ActionContext:
+class ActionContext(Generic[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
     """Holds the runtime context required to execute a pipeline action.
 
     Attributes:
-        pipeline_inputs_microbatches: Per-microbatch input tensors, indexed by microbatch.
-        pipeline_kwargs_microbatches: Per-microbatch keyword arguments, indexed by microbatch.
+        pipeline_inputs_microbatches: Per-microbatch ``PipelineInput``, indexed by microbatch.
+        pipeline_shared_microbatches: Per-microbatch ``SharedInput``, indexed by microbatch.
         stages: A mapping of stage indices to their active PipelineStage instances.
         communications: The handler for P2P communications.
         callback: The handler for either loss computation or result processing.
     """
 
-    pipeline_inputs_microbatches: tuple[dict[str, torch.Tensor], ...]
-    pipeline_kwargs_microbatches: tuple[dict[str, Any], ...]
+    pipeline_inputs_microbatches: tuple[TPipelineInput, ...]
+    pipeline_shared_microbatches: tuple[TSharedInput, ...]
 
-    stages: dict[int, PipelineStage]
+    stages: dict[int, PipelineStage[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]]
     communications: PipelineCommunicationHandler
-    callback: PipelineLossHandler | PipelineResultHandler
+    callback: PipelineLossHandler[TPipelineOutput] | PipelineResultHandler[TPipelineOutput]
 
 
 class ActionWorkType(StrEnum):
@@ -51,7 +50,7 @@ class ActionBase(abc.ABC):
     """
 
     @abc.abstractmethod
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         """Executes the action logic using the provided context.
 
         Args:
@@ -68,7 +67,7 @@ class ActionBase(abc.ABC):
     @property
     @abc.abstractmethod
     def has_backward_work(self) -> bool:
-        """Returns True if this action involves backward pass computations."""
+        """Returns True if this action is part of the backward pass."""
         ...
 
     @abc.abstractmethod
@@ -89,7 +88,7 @@ class ForwardSendAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         ctx.communications.schedule_fwd_send(self.stage_idx, self.microbatch_idx)
 
     @property
@@ -116,7 +115,7 @@ class BackwardSendAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         ctx.communications.schedule_bwd_send(self.stage_idx, self.microbatch_idx)
 
     @property
@@ -143,7 +142,7 @@ class ForwardReceiveAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         ctx.communications.schedule_fwd_recv(self.stage_idx, self.microbatch_idx)
 
     @property
@@ -152,7 +151,7 @@ class ForwardReceiveAction(ActionBase):
 
     @property
     def has_backward_work(self) -> bool:
-        return True
+        return False
 
     def __str__(self) -> str:
         return f"{self.stage_idx}RECV_F{self.microbatch_idx}"
@@ -170,7 +169,7 @@ class BackwardReceiveAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         ctx.communications.schedule_bwd_recv(self.stage_idx, self.microbatch_idx)
 
     @property
@@ -197,7 +196,7 @@ class ForwardComputeAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         stage = ctx.stages[self.stage_idx]
 
         if not stage.info.is_current_stage_first and self.stage_idx - 1 not in ctx.stages:
@@ -206,15 +205,15 @@ class ForwardComputeAction(ActionBase):
         stage.forward_one_chunk(
             microbatch_index=self.microbatch_idx,
             pipeline_inputs=ctx.pipeline_inputs_microbatches[self.microbatch_idx],
-            pipeline_kwargs=ctx.pipeline_kwargs_microbatches[self.microbatch_idx],
+            pipeline_shared=ctx.pipeline_shared_microbatches[self.microbatch_idx],
         )
-        result = stage.get_local_fwd_output(self.microbatch_idx)
 
         if stage.info.is_current_stage_last:
-            ctx.callback.trigger(result, self.microbatch_idx)
-
-        if not stage.info.is_current_stage_last and self.stage_idx + 1 in ctx.stages:
-            ctx.stages[self.stage_idx + 1].set_local_fwd_input(inputs=result, microbatch_index=self.microbatch_idx)
+            ctx.callback.trigger(stage.get_pipeline_output(self.microbatch_idx), self.microbatch_idx)
+        elif self.stage_idx + 1 in ctx.stages:
+            ctx.stages[self.stage_idx + 1].set_local_fwd_input(
+                inputs=stage.get_produced_transfer(self.microbatch_idx), microbatch_index=self.microbatch_idx
+            )
 
     @property
     def work_type(self) -> ActionWorkType:
@@ -244,7 +243,7 @@ class BackwardFullInputComputeAction(ActionBase):
     microbatch_idx: int
     full_backward: bool
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         stage = ctx.stages[self.stage_idx]
 
         if not stage.info.is_current_stage_last and self.stage_idx + 1 not in ctx.stages:
@@ -287,7 +286,7 @@ class BackwardWeightComputeAction(ActionBase):
     stage_idx: int
     microbatch_idx: int
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         stage = ctx.stages[self.stage_idx]
 
         stage.backward_weight_one_chunk(microbatch_index=self.microbatch_idx)
@@ -316,7 +315,7 @@ class ComposeAction(ActionBase):
 
     actions: tuple[ActionBase, ...]
 
-    def apply(self, ctx: ActionContext):
+    def apply(self, ctx: ActionContext[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
         for act in self.actions:
             act.apply(ctx)
 
@@ -324,7 +323,7 @@ class ComposeAction(ActionBase):
     def work_type(self) -> ActionWorkType:
         sub_work_types = {x.work_type for x in self.actions}
         if len(sub_work_types) != 1:
-            raise ValueError("")
+            raise ValueError("A ComposeAction must group sub-actions of a single work type")
         return next(iter(sub_work_types))
 
     @property

--- a/d9d/pipelining/infra/schedule/component/runtime/callback.py
+++ b/d9d/pipelining/infra/schedule/component/runtime/callback.py
@@ -1,12 +1,14 @@
+from typing import Generic
+
 import torch
 
-from d9d.pipelining.api import PipelineLossFn, PipelineResultFn
+from d9d.pipelining.api import PipelineLossFn, PipelineResultFn, TPipelineOutput
 
 
-class PipelineResultHandler:
+class PipelineResultHandler(Generic[TPipelineOutput]):
     """Wraps a callback function to handle results from pipeline execution."""
 
-    def __init__(self, callback_fn: PipelineResultFn):
+    def __init__(self, callback_fn: PipelineResultFn[TPipelineOutput]):
         """Constructs PipelineResultHandler object.
 
         Args:
@@ -14,40 +16,44 @@ class PipelineResultHandler:
         """
         self._callback_fn = callback_fn
 
-    def trigger(self, forward_result: dict[str, torch.Tensor], microbatch_index: int):
+    def trigger(self, forward_result: TPipelineOutput, microbatch_index: int):
         """Invokes the underlying callback with the provided results.
 
         Args:
-            forward_result: Dictionary of output tensors from the pipeline.
+            forward_result: The ``PipelineOutput`` produced by the last stage.
             microbatch_index: The index of the current micro-batch.
         """
         self._callback_fn(forward_result, microbatch_index)
 
 
-class PipelineLossHandler:
+class PipelineLossHandler(Generic[TPipelineOutput]):
     """Manages loss computation and state caching across forward and backward passes."""
 
-    def __init__(self, loss_fn: PipelineLossFn):
+    def __init__(self, callback_fn: PipelineLossFn[TPipelineOutput]):
         """Constructs the loss handler.
 
         Args:
-            loss_fn: The callable that computes loss from model outputs.
+            callback_fn: The callable that computes loss from model outputs.
         """
-        self._loss_fn = loss_fn
+        self._callback_fn = callback_fn
         self._cached_values: dict[int, torch.Tensor] = {}
 
-    def trigger(self, forward_result: dict[str, torch.Tensor], microbatch_index: int):
+    def trigger(self, forward_result: TPipelineOutput, microbatch_index: int):
         """Computes loss for a given microbatch result and caches it.
 
         Args:
-            forward_result: The output from the last stage of the model.
+            forward_result: The ``PipelineOutput`` produced by the last stage.
             microbatch_index: The index of the microbatch being processed.
         """
-        result = self._loss_fn(forward_result, microbatch_index)
+        result = self._callback_fn(forward_result, microbatch_index)
         self._cached_values[microbatch_index] = result
 
     def acquire_loss(self, microbatch_index: int) -> torch.Tensor:
-        """Retrieves the cached loss tensor for the backward pass and removes it from the cache.
+        """Retrieves and releases the cached loss tensor for the backward pass.
+
+        Consume-once: the loss is removed from the cache, so the handler drops its reference to it.
+        The loss is triggered once and acquired once, so a second acquire for the same microbatch
+        raises.
 
         Args:
             microbatch_index: The index of the microbatch.
@@ -56,9 +62,9 @@ class PipelineLossHandler:
             The previously computed loss tensor.
 
         Raises:
-            ValueError: If the loss for this microbatch hasn't been computed yet.
+            ValueError: If the loss for this microbatch has not been computed (or was already acquired).
         """
         if microbatch_index not in self._cached_values:
-            raise ValueError()
+            raise ValueError(f"No cached loss for microbatch {microbatch_index}; it must be triggered before backward")
 
-        return self._cached_values[microbatch_index]
+        return self._cached_values.pop(microbatch_index)

--- a/d9d/pipelining/infra/schedule/component/runtime/communications.py
+++ b/d9d/pipelining/infra/schedule/component/runtime/communications.py
@@ -53,7 +53,7 @@ class PipelineCommunicationHandler:
         key = (stage_idx, microbatch_idx)
 
         if key in self._forward_receive_ops:
-            raise ValueError()
+            raise ValueError(f"A forward receive is already pending for S{stage_idx}B{microbatch_idx}")
 
         work = _schedule_batched_p2p(stage.get_fwd_recv_ops(microbatch_idx))
         self._forward_receive_ops[key] = work
@@ -73,7 +73,7 @@ class PipelineCommunicationHandler:
         key = (stage_idx, microbatch_idx)
 
         if key in self._backward_receive_ops:
-            raise ValueError()
+            raise ValueError(f"A backward receive is already pending for S{stage_idx}B{microbatch_idx}")
 
         work = _schedule_batched_p2p(stage.get_bwd_recv_ops(microbatch_idx))
 

--- a/d9d/pipelining/infra/schedule/component/runtime/executor.py
+++ b/d9d/pipelining/infra/schedule/component/runtime/executor.py
@@ -1,9 +1,9 @@
 import dataclasses
 from typing import TYPE_CHECKING, Any
 
-import torch
 from torch.autograd.profiler import record_function
 
+from d9d.core import pytree
 from d9d.core.dist_context import DistributedContext
 from d9d.core.types import TensorSpec
 from d9d.pipelining.api import PipelineLossFn, PipelineResultFn, PipelineSchedule
@@ -20,24 +20,24 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class _MicrobatchInputSpec:
-    """A hashable shape/dtype fingerprint of one microbatch's named input tensors."""
+    """A hashable shape/dtype fingerprint of one microbatch's ``PipelineInput`` tensor leaves."""
 
-    named_specs: tuple[tuple[str, TensorSpec], ...]
+    leaf_specs: tuple[TensorSpec, ...]
 
     @classmethod
-    def of(cls, microbatch: dict[str, torch.Tensor]) -> "_MicrobatchInputSpec":
-        """Builds a fingerprint from a single microbatch's inputs.
+    def of(cls, microbatch: Any) -> "_MicrobatchInputSpec":
+        """Builds a fingerprint from a single microbatch's ``PipelineInput``.
 
         Args:
-            microbatch: The microbatch's input tensors.
+            microbatch: The microbatch's ``PipelineInput`` PyTree.
 
         Returns:
-            A hashable fingerprint of its named tensor specs.
+            A hashable fingerprint of its tensor leaf specs, in flatten (leaf) order.
         """
         return cls(
-            named_specs=tuple(
-                (name, TensorSpec(shape=tuple(tensor.shape), dtype=tensor.dtype, layout=tensor.layout))
-                for name, tensor in sorted(microbatch.items())
+            leaf_specs=tuple(
+                TensorSpec(shape=tuple(tensor.shape), dtype=tensor.dtype, layout=tensor.layout)
+                for tensor in pytree.tree_leaves(microbatch)
             )
         )
 
@@ -53,11 +53,11 @@ class _BufferConfig:
     microbatches: tuple[_MicrobatchInputSpec, ...]
 
     @classmethod
-    def of(cls, inputs_microbatches: tuple[dict[str, torch.Tensor], ...]) -> "_BufferConfig":
+    def of(cls, inputs_microbatches: tuple[Any, ...]) -> "_BufferConfig":
         """Builds a buffer config from the per-microbatch inputs of a pack.
 
         Args:
-            inputs_microbatches: The per-microbatch input tensors whose shapes/dtypes size the buffers.
+            inputs_microbatches: The per-microbatch ``PipelineInput`` whose shapes/dtypes size buffers.
 
         Returns:
             A hashable buffer configuration key covering every microbatch.
@@ -65,7 +65,7 @@ class _BufferConfig:
         return cls(microbatches=tuple(_MicrobatchInputSpec.of(microbatch) for microbatch in inputs_microbatches))
 
 
-class PipelineScheduleExecutor(PipelineSchedule):
+class PipelineScheduleExecutor(PipelineSchedule[Any, Any, Any]):
     """Executes a defined pipeline schedule by interpreting a sequence of actions."""
 
     def __init__(
@@ -88,7 +88,7 @@ class PipelineScheduleExecutor(PipelineSchedule):
 
         self._buffer_config: _BufferConfig | None = None
 
-    def _configure_buffers(self, inputs_microbatches: tuple[dict[str, torch.Tensor], ...], has_backward: bool):
+    def _configure_buffers(self, inputs_microbatches: tuple[Any, ...], has_backward: bool):
         config = _BufferConfig.of(inputs_microbatches)
         if config == self._buffer_config:
             return
@@ -103,19 +103,19 @@ class PipelineScheduleExecutor(PipelineSchedule):
 
     def step(
         self,
-        inputs_microbatches: tuple[dict[str, torch.Tensor], ...],
-        kwargs_microbatches: tuple[dict[str, Any], ...],
+        inputs_microbatches: tuple[Any, ...],
+        shared_microbatches: tuple[Any, ...],
         callback: PipelineLossFn | PipelineResultFn,
     ):
         num_microbatches = len(inputs_microbatches)
         if num_microbatches == 0:
             raise ValueError("Cannot run a pipeline step over an empty pack")
-        if len(kwargs_microbatches) != num_microbatches:
-            raise ValueError("inputs_microbatches and kwargs_microbatches must have the same length")
+        if len(shared_microbatches) != num_microbatches:
+            raise ValueError("inputs_microbatches and shared_microbatches must have the same length")
 
-        expected_names = inputs_microbatches[0].keys()
-        if any(microbatch.keys() != expected_names for microbatch in inputs_microbatches):
-            raise ValueError("All microbatches in a pack must have the same input names")
+        expected_structure = pytree.tree_flatten(inputs_microbatches[0])[1]
+        if any(pytree.tree_flatten(microbatch)[1] != expected_structure for microbatch in inputs_microbatches):
+            raise ValueError("All microbatches in a pack must share the same PipelineInput structure")
 
         program = self._programs.program_for(num_microbatches)
         self._configure_buffers(inputs_microbatches, program.has_backward)
@@ -127,19 +127,19 @@ class PipelineScheduleExecutor(PipelineSchedule):
         for stage in self._stages.values():
             stage.reset()
 
+        ctx = ActionContext(
+            callback=callback_fn,
+            stages=self._stages,
+            communications=self._comm_handler,
+            pipeline_inputs_microbatches=inputs_microbatches,
+            pipeline_shared_microbatches=shared_microbatches,
+        )
+
         for action in program.program_this_rank:
             with record_function(str(action)):
                 self._dist_ctx.logger.debug(f"Running pipeline action {action}")
-                action.apply(
-                    ActionContext(
-                        callback=callback_fn,
-                        stages=self._stages,
-                        communications=self._comm_handler,
-                        pipeline_inputs_microbatches=inputs_microbatches,
-                        pipeline_kwargs_microbatches=kwargs_microbatches,
-                    )
-                )
+                action.apply(ctx)
 
-        self._dist_ctx.logger.debug("Waiting for potentially hanging PP send comms")
-        self._comm_handler.wait_send_all()  # finalize just in case
+        self._dist_ctx.logger.debug("Waiting for pending PP send comms")
+        self._comm_handler.wait_send_all()
         self._dist_ctx.logger.debug("End pipeline step")

--- a/d9d/pipelining/infra/schedule/component/runtime/offline.py
+++ b/d9d/pipelining/infra/schedule/component/runtime/offline.py
@@ -6,7 +6,7 @@ from torch import nn
 from d9d.pipelining.api import PipelineLossFn, PipelineResultFn, PipelineSchedule
 
 
-class OfflinePipelineExecutor(PipelineSchedule):
+class OfflinePipelineExecutor(PipelineSchedule[Any, Any, Any]):
     """Executes the model immediately without pipeline parallelism.
 
     This schedule treats the execution as a single stage, running the forward and optionally backward
@@ -26,21 +26,21 @@ class OfflinePipelineExecutor(PipelineSchedule):
 
     def step(
         self,
-        inputs_microbatches: tuple[dict[str, torch.Tensor], ...],
-        kwargs_microbatches: tuple[dict[str, Any], ...],
+        inputs_microbatches: tuple[Any, ...],
+        shared_microbatches: tuple[Any, ...],
         callback: PipelineLossFn | PipelineResultFn,
     ):
         num_microbatches = len(inputs_microbatches)
         if num_microbatches == 0:
             raise ValueError("Cannot run a pipeline step over an empty pack")
-        if len(kwargs_microbatches) != num_microbatches:
-            raise ValueError("inputs_microbatches and kwargs_microbatches must have the same length")
+        if len(shared_microbatches) != num_microbatches:
+            raise ValueError("inputs_microbatches and shared_microbatches must have the same length")
 
         for microbatch_idx in range(num_microbatches):
             inputs = inputs_microbatches[microbatch_idx]
-            kwargs = kwargs_microbatches[microbatch_idx]
+            shared = shared_microbatches[microbatch_idx]
 
-            result = self._model(**inputs, **kwargs)
+            result = self._model(inputs, shared)
             processing_result = callback(result, microbatch_idx)
 
             if self._do_backward:

--- a/d9d/pipelining/infra/stage/communications.py
+++ b/d9d/pipelining/infra/stage/communications.py
@@ -1,150 +1,69 @@
 import dataclasses
+from typing import Any, Generic, cast
 
 import torch
 import torch.distributed as dist
 
-from d9d.core.types import TensorSpec
+from d9d.core import pytree
+from d9d.core.types import PyTree, TensorSpec
+from d9d.pipelining.api import TStageTransfer
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class ReceiveStageInput:
-    """Instruction to receive a specific tensor from a previous stage (or next stage during backward).
-
-    Attributes:
-        name: A unique identifier for the communication operation.
-        from_stage: The stage index sending the data.
-        spec: The shape/dtype/layout describing the tensor to receive.
-    """
-
-    name: str
-    from_stage: int
-    spec: TensorSpec
+def _is_spec(node: Any) -> bool:
+    return isinstance(node, TensorSpec)
 
 
-@dataclasses.dataclass
-class StartStageInput:
-    """Instruction indicating that the input for this stage does not come from communication.
-
-    (e.g., this is the first stage receiving data loader inputs).
-    """
-
-
-StageInput = ReceiveStageInput | StartStageInput
-
-
-@dataclasses.dataclass(kw_only=True, slots=True)
-class SendStageOutput:
-    """Instruction to send a specific tensor to a next stage (or previous if backward).
+@dataclasses.dataclass(frozen=True, slots=True)
+class _MicrobatchReceivePlan:
+    """How to receive and rebuild one microbatch's incoming transfer.
 
     Attributes:
-        to_stage: The stage index receiving the data.
+        leaf_specs: The specs of the ordered tensor leaves to receive, in transfer flatten order;
+            each sizes one receive buffer.
+        treespec: The structure spec that rebuilds the ``StageTransfer`` from the received leaves.
     """
 
-    to_stage: int
+    leaf_specs: list[TensorSpec]
+    treespec: pytree.PyTreeSpec
 
 
-@dataclasses.dataclass
-class EndStageOutput:
-    """Instruction indicating that the output of this stage is not sent anywhere.
+def _build_receive_plan(spec_per_microbatch: tuple[PyTree[TensorSpec], ...]) -> list[_MicrobatchReceivePlan]:
+    plan_per_microbatch: list[_MicrobatchReceivePlan] = []
 
-    (e.g., this is the last stage computing loss).
-    """
+    for pytree_specs in spec_per_microbatch:
+        # tree_flatten is guaranteed to be deterministic in order
+        leaf_specs, treespec = pytree.tree_flatten(pytree_specs, is_leaf=_is_spec)
+        plan_per_microbatch.append(_MicrobatchReceivePlan(leaf_specs=leaf_specs, treespec=treespec))
+
+    return plan_per_microbatch
 
 
-StageOutput = SendStageOutput | EndStageOutput
-
-
-class StageCommunicationHandler:
-    """Manages Point-to-Point (P2P) communication descriptors for a data flow direction within a pipeline stage.
-
-    This class handles the creation of P2P operations (send/recv) across multiple microbatches,
-    managing buffers and mapping logical stage indices to physical ranks.
-    """
+class StageReceiver(Generic[TStageTransfer]):
+    """Receives one stage's incoming ``StageTransfer`` from a single peer stage."""
 
     def __init__(
         self,
-        name: str,
-        stage_index: int,
-        input_stage_index: int | None,
-        input_args_per_microbatch: tuple[dict[str, TensorSpec], ...],
-        output_stage_index: int | None,
-        output_args: dict[str, TensorSpec],
-        stage_idx_to_host_rank: dict[int, int],
+        peer_global_rank: int,
+        spec_per_microbatch: tuple[PyTree[TensorSpec], ...],
         group: dist.ProcessGroup,
+        requires_grad: bool,
     ):
-        """Constructs a StageCommunicationHandler object.
+        """Constructs a StageReceiver object.
 
         Args:
-            name: Name prefix for this handler (e.g., 'fwd', 'bwd').
-            stage_index: The logical index of the current stage.
-            input_stage_index: The logical index of the stage providing inputs, or None if inputs are local.
-            input_args_per_microbatch: Per-microbatch input specs (shape/dtype/layout); the receive buffer for
-                microbatch ``i`` is sized from entry ``i``. The number of microbatches is its length.
-            output_stage_index: The logical index of the stage consuming outputs, or None if outputs are terminal.
-            output_args: Structural output specs (names). Send buffers are not pre-allocated — send ops read
-                the produced tensors directly — so only names matter here, not per-microbatch shapes.
-            stage_idx_to_host_rank: Mapping from logical stage indices to physical world ranks.
+            peer_global_rank: The global (world) rank of the peer stage sending the transfer.
+            spec_per_microbatch: The incoming transfer spec (a ``TensorSpec`` PyTree) for each
+                microbatch in the pack; the receive buffers for microbatch ``i`` are sized from
+                entry ``i``.
             group: The process group strictly for pipeline communication.
+            requires_grad: Whether receive buffers should require gradients (enables gradient flow
+                from backward stages to forward stages).
         """
-        self._input_handlers = self._build_inputs(
-            name=name,
-            stage_index=stage_index,
-            input_stage_index=input_stage_index,
-            input_args_per_microbatch=input_args_per_microbatch,
-        )
-        self._output_handlers = self._build_outputs(output_stage_index=output_stage_index, output_args=output_args)
-
-        self._stage_idx_to_host_rank = stage_idx_to_host_rank
+        self._peer_global_rank = peer_global_rank
         self._group = group
-
-        self._input_requires_grad = False
-        # Currently-allocated receive buffers, keyed by microbatch then input name. Populated lazily on
-        # receive/local-set and released (popped) when consumed by get_inputs, so only in-flight
-        # microbatches hold live buffers at any moment.
-        self._live_buffers: dict[int, dict[str, torch.Tensor]] = {}
-
-    @staticmethod
-    def _build_inputs(
-        name: str,
-        stage_index: int,
-        input_stage_index: int | None,
-        input_args_per_microbatch: tuple[dict[str, TensorSpec], ...],
-    ) -> dict[int, dict[str, StageInput]]:
-        handlers: dict[int, dict[str, StageInput]] = {}
-
-        for chunk_id, input_args in enumerate(input_args_per_microbatch):
-            handlers[chunk_id] = {}
-            for input_name, input_spec in input_args.items():
-                if input_stage_index is None:
-                    handlers[chunk_id][input_name] = StartStageInput()
-                else:
-                    handlers[chunk_id][input_name] = ReceiveStageInput(
-                        name=f"{name}_recv_from_{input_stage_index}_to_{stage_index}[{chunk_id}][{input_name}]",
-                        from_stage=input_stage_index,
-                        spec=input_spec,
-                    )
-        return handlers
-
-    @staticmethod
-    def _build_outputs(output_stage_index: int | None, output_args: dict[str, TensorSpec]) -> dict[str, StageOutput]:
-        handlers: dict[str, StageOutput] = {}
-
-        for output_name in output_args:
-            if output_stage_index is None:
-                handlers[output_name] = EndStageOutput()
-            else:
-                handlers[output_name] = SendStageOutput(to_stage=output_stage_index)
-        return handlers
-
-    def set_input_requires_grad_(self, requires_grad: bool):
-        """Records whether receive buffers should require gradients.
-
-        Typically used to enable gradient flow from backward stages to forward stages.
-
-        Args:
-            requires_grad: Whether the buffers should require gradients.
-        """
-        self._input_requires_grad = requires_grad
+        self._requires_grad = requires_grad
+        self._plan_per_microbatch = _build_receive_plan(spec_per_microbatch)
+        self._live_buffers: dict[int, list[torch.Tensor]] = {}
 
     def _allocate_buffer(self, spec: TensorSpec) -> torch.Tensor:
         return torch.empty(
@@ -152,118 +71,94 @@ class StageCommunicationHandler:
             dtype=spec.dtype,
             layout=spec.layout,
             device="cuda",  # force device
-            requires_grad=self._input_requires_grad,
+            requires_grad=self._requires_grad,
         )
 
-    def set_inputs_local(self, inputs: dict[str, torch.Tensor], microbatch_index: int):
-        """Manually fills the input buffer for a specific microbatch with local data.
+    def set_inputs_local(self, inputs: TStageTransfer, microbatch_index: int):
+        """Manually fills the input buffer for a specific microbatch with a local transfer.
 
-        This is used when the stage is the first in the pipeline or receives data
-        from a dataloader rather than via network communication.
+        Used for the V-shape schedulers, where the producing stage lives on the same rank and its
+        transfer is handed over directly rather than received via the network.
 
         Args:
-            inputs: Dictionary of input tensors.
+            inputs: The ``StageTransfer`` produced by the peer stage.
             microbatch_index: The microbatch identifier.
-
-        Raises:
-            RuntimeError: If tried to set a buffer for a no-receive stage input.
         """
-        live = self._live_buffers.setdefault(microbatch_index, {})
-        for input_name, input_value in inputs.items():
-            handler = self._input_handlers[microbatch_index][input_name]
-            if not isinstance(handler, ReceiveStageInput):
-                raise RuntimeError("Tried to set a buffer of no-receive stage input")
-            live[input_name] = input_value.detach().requires_grad_(self._input_requires_grad)
+        self._live_buffers[microbatch_index] = [
+            leaf.detach().requires_grad_(self._requires_grad) for leaf in pytree.tree_leaves(inputs)
+        ]
 
-    def get_inputs(self, microbatch_index: int) -> dict[str, torch.Tensor]:
-        """Retrieves and releases the input tensors for a specific microbatch.
+    def pop_inputs(self, microbatch_index: int) -> TStageTransfer:
+        """Retrieves and releases the input transfer for a specific microbatch.
 
-        Ownership of the buffers is transferred to the caller: the handler drops its references so the
-        memory can be freed once the caller (e.g. the forward/backward cache) releases it.
+        Consume-once: the buffers are removed from the handler, transferring ownership to the caller so
+        the memory can be freed once the caller (e.g. the forward/backward cache) releases it. Calling
+        this twice for the same microbatch raises ``KeyError``.
 
         Args:
             microbatch_index: The microbatch identifier.
 
         Returns:
-            Dictionary mapping input names to tensors.
+            The received ``StageTransfer``, reconstructed from the buffers.
 
         Raises:
-            RuntimeError: If tried to get a buffer for a no-receive stage input.
             KeyError: If no buffer has been allocated for the microbatch (never received or set).
         """
-        for input_info in self._input_handlers[microbatch_index].values():
-            if not isinstance(input_info, ReceiveStageInput):
-                raise RuntimeError("Tried to get a buffer of no receive stage input")
+        treespec = self._plan_per_microbatch[microbatch_index].treespec
+        buffers = self._live_buffers.pop(microbatch_index)
+        return cast(TStageTransfer, pytree.tree_unflatten(treespec, buffers))
 
-        return self._live_buffers.pop(microbatch_index)
+    def receive(self, microbatch_index: int) -> list[dist.P2POp]:
+        """Allocates the receive buffers for a microbatch and generates the P2P receive operations.
 
-    def create_receive_ops(self, microbatch_index: int) -> list[dist.P2POp]:
-        """Generates the PyTorch P2P receive operations for a specific microbatch.
-
-        Allocates the receive buffers for the microbatch on demand and registers them as live until
-        consumed by :meth:`get_inputs`.
+        Allocates one buffer per transfer leaf (in flatten order) and registers them as live until
+        consumed by :meth:`pop_inputs`, then builds the ``dist.irecv`` ops that fill them.
 
         Args:
             microbatch_index: The microbatch identifier.
 
         Returns:
             A list of `dist.P2POp` objects configured for `dist.irecv`.
-
-        Raises:
-            ValueError: If an unknown input handler type is encountered.
         """
         ops = []
+        buffers = []
 
-        inputs = self._input_handlers[microbatch_index]
-        live = self._live_buffers.setdefault(microbatch_index, {})
-        # sort ops by parameter names to ensure receive ops are ordered the same for send and recv
-        for input_name, input_info in sorted(inputs.items(), key=lambda x: x[0]):
-            match input_info:
-                case StartStageInput():
-                    pass
-                case ReceiveStageInput():
-                    buffer = self._allocate_buffer(input_info.spec)
-                    live[input_name] = buffer
-                    peer_rank = self._stage_idx_to_host_rank[input_info.from_stage]
-                    peer_global_rank = dist.get_global_rank(self._group, peer_rank)
-                    op = dist.P2POp(dist.irecv, buffer, peer_global_rank, self._group)
-                    ops.append(op)
-                case _:
-                    raise ValueError()
+        for leaf_spec in self._plan_per_microbatch[microbatch_index].leaf_specs:
+            buffer = self._allocate_buffer(leaf_spec)
+            buffers.append(buffer)
+            ops.append(dist.P2POp(dist.irecv, buffer, self._peer_global_rank, self._group))
 
-        return ops
-
-    def create_send_ops(self, send_contents: dict[str, torch.Tensor]) -> list[dist.P2POp]:
-        """Generates the PyTorch P2P send operations for the provided tensors.
-
-        Args:
-            send_contents: Dictionary of tensors to send.
-
-        Returns:
-            A list of `dist.P2POp` objects configured for `dist.isend`.
-
-        Raises:
-            ValueError: If an unknown output handler type is encountered.
-        """
-        ops = []
-
-        # sort ops by parameter names to ensure receive ops are ordered the same for send and recv
-        for output_name, output_info in sorted(self._output_handlers.items(), key=lambda x: x[0]):
-            output_tensor = send_contents[output_name]
-
-            match output_info:
-                case EndStageOutput():
-                    pass
-                case SendStageOutput():
-                    peer_rank = self._stage_idx_to_host_rank[output_info.to_stage]
-                    peer_global_rank = dist.get_global_rank(self._group, peer_rank)
-                    op = dist.P2POp(dist.isend, output_tensor, peer_global_rank, self._group)
-                    ops.append(op)
-                case _:
-                    raise ValueError()
-
+        self._live_buffers[microbatch_index] = buffers
         return ops
 
     def reset(self):
         """Resets the internal state, releasing any live receive buffers."""
         self._live_buffers.clear()
+
+
+class StageSender(Generic[TStageTransfer]):
+    """Sends one stage's outgoing ``StageTransfer`` to a single peer stage."""
+
+    def __init__(self, peer_global_rank: int, group: dist.ProcessGroup):
+        """Constructs a StageSender object.
+
+        Args:
+            peer_global_rank: The global (world) rank of the peer stage consuming the transfer.
+            group: The process group strictly for pipeline communication.
+        """
+        self._peer_global_rank = peer_global_rank
+        self._group = group
+
+    def send(self, send_contents: TStageTransfer) -> list[dist.P2POp]:
+        """Generates the PyTorch P2P send operations for a transfer.
+
+        Args:
+            send_contents: The ``StageTransfer`` to send (only its tensor leaves are read).
+
+        Returns:
+            A list of `dist.P2POp` objects configured for `dist.isend`.
+        """
+        return [
+            dist.P2POp(dist.isend, leaf, self._peer_global_rank, self._group)
+            for leaf in pytree.tree_leaves(send_contents)
+        ]

--- a/d9d/pipelining/infra/stage/computations.py
+++ b/d9d/pipelining/infra/stage/computations.py
@@ -1,12 +1,13 @@
 import dataclasses
-from collections.abc import Iterator, Mapping
-from typing import Any, cast
+from collections.abc import Iterator
+from typing import Generic, cast
 
 import torch
 from torch import nn
 from torch.autograd.graph import Node
 
 from d9d.core import pytree
+from d9d.pipelining.api import TPipelineInput, TPipelineOutput, TSharedInput, TStageTransfer
 
 from .splitgrad import (
     ParamGroup,
@@ -20,14 +21,21 @@ from .splitgrad import (
 
 
 @dataclasses.dataclass(slots=True)
-class ForwardCache:
-    """Stores the inputs and outputs of a forward pass to be used later in the backward pass."""
+class ForwardCache(Generic[TPipelineInput, TStageTransfer, TPipelineOutput]):
+    """Stores the inputs and outputs of a forward pass to be used later in the backward pass.
 
-    inputs: dict[str, torch.Tensor]
-    outputs: dict[str, torch.Tensor]
+    Attributes:
+        inputs: The stage's incoming ``StageTransfer`` (or ``PipelineInput`` on the first stage) as a
+            PyTree.
+        outputs: The stage's produced ``StageTransfer`` (or ``PipelineOutput`` on the last stage) as a
+            PyTree.
+    """
+
+    inputs: TPipelineInput | TStageTransfer
+    outputs: TStageTransfer | TPipelineOutput
 
 
-class ForwardComputeHandler:
+class ForwardComputeHandler(Generic[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
     """Handles the execution of the forward pass for a pipeline stage module.
 
     Maintains a cache of inputs and outputs indexed by microbatch ID.
@@ -43,45 +51,40 @@ class ForwardComputeHandler:
         self._stage_idx = stage_index
         self._module = module
 
-        self._cache: dict[int, ForwardCache] = {}
+        self._cache: dict[int, ForwardCache[TPipelineInput, TStageTransfer, TPipelineOutput]] = {}
 
-    def run(self, microbatch_index: int, inputs: dict[str, torch.Tensor], kwargs: dict[str, Any]):
+    def run(self, microbatch_index: int, inputs: TPipelineInput | TStageTransfer, shared: TSharedInput):
         """Executes the module's forward pass.
 
         Args:
             microbatch_index: Identifier for the current microbatch.
-            inputs: Dictionary of input tensors.
-            kwargs: Additional keyword arguments for the module.
+            inputs: The stage's ``PipelineInput`` (first stage) or incoming ``StageTransfer``.
+            shared: The ``SharedInput`` passed to every stage.
 
         Raises:
             RuntimeError: If the forward pass implementation fails.
-            ValueError: If the module output is not a dictionary.
         """
-        # Compute forward
         try:
-            output = self._module(**inputs, **kwargs)
+            output = self._module(inputs, shared)
         except Exception as e:
             raise RuntimeError(f"S{self._stage_idx}B{microbatch_index} failed to run forward") from e
 
-        if not isinstance(output, Mapping):
-            raise ValueError("Currently, pipelined models should output dict[str, torch.Tensor | None]")
-
-        output = {k: v for k, v in output.items() if v is not None}
-
         self._cache[microbatch_index] = ForwardCache(inputs=inputs, outputs=output)
 
-    def get_outputs(self, microbatch_index: int) -> dict[str, torch.Tensor]:
+    def get_outputs(self, microbatch_index: int) -> TStageTransfer | TPipelineOutput:
         """Retrieves cached outputs for a specific microbatch without removing them.
 
         Args:
             microbatch_index: Identifier for the microbatch.
 
         Returns:
-            Dictionary of output tensors.
+            The produced transfer/output PyTree.
         """
         return self._cache[microbatch_index].outputs
 
-    def pop_inputs_outputs(self, microbatch_index: int) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    def pop_inputs_outputs(
+        self, microbatch_index: int
+    ) -> tuple[TPipelineInput | TStageTransfer, TStageTransfer | TPipelineOutput]:
         """Retrieves and removes the cached inputs and outputs for a specific microbatch.
 
         Typically called when initiating the backward pass.
@@ -97,64 +100,149 @@ class ForwardComputeHandler:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class BackwardCacheInputForWeight:
-    """State preserved after calculating input gradients, pending weight gradient calculation."""
+class _SendableInputGrads:
+    """Input gradients ready to send back to the previous stage.
 
-    inputs_grad: dict[str, torch.Tensor]
+    Attributes:
+        leaves: The input gradient tensor leaves, in the stage's input-transfer flatten order.
+        treespec: The structure spec that rebuilds the input ``StageTransfer`` from ``leaves``.
+    """
+
+    leaves: list[torch.Tensor | None]
+    treespec: pytree.PyTreeSpec
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferredFullBackward:
+    """A full backward to replay at weight time.
+
+    Used by the first stage, which cannot split input- and weight-gradient passes (it has no input
+    peer to send input grads to), so it stashes the flattened tensors and runs a full backward when
+    the weight phase arrives.
+
+    Attributes:
+        outputs: The output tensor leaves to backprop from.
+        output_grads: Their gradient leaves, or None to seed an implicit unit gradient.
+        inputs: The input tensor leaves the backward flows into.
+    """
+
+    outputs: list[torch.Tensor]
+    output_grads: list[torch.Tensor] | None
+    inputs: list[torch.Tensor]
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class _DeferredWeightBackward:
+    """A weight-gradient-only backward to replay from saved param groups (the ZB split optimization).
+
+    Attributes:
+        param_groups: The parameter groups whose weight gradients still need accumulating.
+        ownership_tokens: Autograd nodes kept alive to own the pending gradient graph.
+    """
+
     param_groups: list[ParamGroup]
     ownership_tokens: list[Node]
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class BackwardCacheInputForFull:
-    stage_outputs_or_loss: list[torch.Tensor]
-    output_grads: list[torch.Tensor] | None
-    input_values: list[torch.Tensor]
+class _BackwardState:
+    """Per-microbatch backward state carried between the backward phases.
 
+    A single entry holds two orthogonal, independently-optional facts:
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class BackwardCacheFull:
-    """State preserved after calculating weight gradients."""
-
-    inputs_grad: dict[str, torch.Tensor | None]
-
-
-class BackwardComputeHandler:
-    """Handles the execution of backward passes for a pipeline stage.
-
-    Supports splitting the backward pass into input-gradients and weight-gradients
-    phases, which is necessary for schedules like ZB.
+    Attributes:
+        sendable_grads: The input gradients ready to send upstream, or None on the first stage.
+        pending_weight: The weight-gradient work still to run, or None after a full backward.
     """
 
-    def __init__(self, stage_index: int, module: nn.Module):
+    sendable_grads: _SendableInputGrads | None
+    pending_weight: _DeferredFullBackward | _DeferredWeightBackward | None
+
+
+@dataclasses.dataclass(slots=True)
+class BackwardSeedLoss:
+    """Backward seed for the last stage.
+
+    The produced output does not leave the pipeline, so backward is seeded directly from the scalar
+    loss with an implicit unit gradient.
+
+    Attributes:
+        loss: The scalar loss produced by the last stage.
+    """
+
+    loss: torch.Tensor
+
+
+@dataclasses.dataclass(slots=True)
+class BackwardSeedTransfer(Generic[TStageTransfer]):
+    """Backward seed for a non-last stage.
+
+    Backward propagates the gradients received from the next stage through the transfer this stage
+    produced in the forward pass.
+
+    Attributes:
+        outputs: The ``StageTransfer`` this stage produced in the forward pass.
+        output_grads: The gradients of the loss w.r.t. ``outputs``, received from the next stage.
+    """
+
+    outputs: TStageTransfer
+    output_grads: TStageTransfer
+
+
+BackwardSeed = BackwardSeedLoss | BackwardSeedTransfer[TStageTransfer]
+
+
+class BackwardComputeHandler(Generic[TPipelineInput, TStageTransfer]):
+    """Handles the execution of backward passes for a pipeline stage.
+
+    Supports splitting the backward pass into input-gradients and weight-gradients phases, which is
+    necessary for schedules like ZB.
+    """
+
+    def __init__(self, stage_index: int, module: nn.Module, has_input_peer: bool):
         """Constructs a BackwardComputeHandler object.
 
         Args:
-            stage_index: Logical index of the stage.
+            stage_index: Logical index of the stage (used only in diagnostics).
             module: The PyTorch module to compute gradients for.
+            has_input_peer: Whether this stage has a previous stage to send input gradients to.
         """
         self._stage_idx = stage_index
         self._module = module
+        self._has_input_peer = has_input_peer
 
-        self._cache: dict[int, BackwardCacheInputForWeight | BackwardCacheInputForFull | BackwardCacheFull] = {}
+        self._cache: dict[int, _BackwardState] = {}
 
     def _parameters_with_grad(self) -> Iterator[nn.Parameter]:
         return (param for param in self._module.parameters() if param.requires_grad)
 
+    def _release_if_complete(self, microbatch_index: int):
+        state = self._cache[microbatch_index]
+        if state.sendable_grads is None and state.pending_weight is None:
+            del self._cache[microbatch_index]
+
+    @staticmethod
+    def _seed_leaves(seed: "BackwardSeed[TStageTransfer]") -> tuple[list[torch.Tensor], list[torch.Tensor] | None]:
+        match seed:
+            case BackwardSeedLoss():
+                return [seed.loss], None
+            case BackwardSeedTransfer():
+                return pytree.tree_leaves(seed.outputs), pytree.tree_leaves(seed.output_grads)
+            case _:
+                raise ValueError("Unknown backward seed type")
+
     def backward_full(
         self,
         microbatch_index: int,
-        inputs: dict[str, torch.Tensor],
-        outputs: dict[str, torch.Tensor],
-        outputs_grad: dict[str, torch.Tensor] | None,
+        inputs: TPipelineInput | TStageTransfer,
+        seed: "BackwardSeed[TStageTransfer]",
     ):
         """Performs a full backward pass (both inputs and weights).
 
         Args:
             microbatch_index: Identifier for the microbatch.
-            inputs: The inputs used in the forward pass.
-            outputs: The outputs produced by the forward pass.
-            outputs_grad: Gradients of the loss with respect to the outputs.
+            inputs: The input transfer used in the forward pass.
+            seed: The downstream backward seed (loss on the last stage, transfer + grads otherwise).
 
         Raises:
             ValueError: If a double backward is attempted for the same microbatch.
@@ -163,24 +251,23 @@ class BackwardComputeHandler:
             raise ValueError(f"S{self._stage_idx}B{microbatch_index} double backward")
 
         input_leaves, input_spec = pytree.tree_flatten(inputs)
+        output_leaves, output_grad_leaves = self._seed_leaves(seed)
 
         inputs_grad_linear = stage_backward_full(
-            outputs=pytree.tree_leaves(outputs),
-            output_grads=pytree.tree_leaves(outputs_grad) if outputs_grad is not None else None,
+            outputs=output_leaves,
+            output_grads=output_grad_leaves,
             inputs=input_leaves,
         )
 
-        if self._stage_idx != 0:
-            self._cache[microbatch_index] = BackwardCacheFull(
-                inputs_grad=cast(dict[str, torch.Tensor | None], pytree.tree_unflatten(input_spec, inputs_grad_linear))
-            )
+        sendable = _SendableInputGrads(leaves=inputs_grad_linear, treespec=input_spec) if self._has_input_peer else None
+        self._cache[microbatch_index] = _BackwardState(sendable_grads=sendable, pending_weight=None)
+        self._release_if_complete(microbatch_index)
 
     def backward_input(
         self,
         microbatch_index: int,
-        inputs: dict[str, torch.Tensor],
-        outputs: dict[str, torch.Tensor],
-        outputs_grad: dict[str, torch.Tensor] | None,
+        inputs: TPipelineInput | TStageTransfer,
+        seed: "BackwardSeed[TStageTransfer]",
     ):
         """Performs a partial backward pass to compute gradients with respect to inputs only.
 
@@ -188,40 +275,41 @@ class BackwardComputeHandler:
 
         Args:
             microbatch_index: Identifier for the microbatch.
-            inputs: The inputs used in the forward pass.
-            outputs: The outputs produced by the forward pass.
-            outputs_grad: Gradients of the loss with respect to the outputs.
+            inputs: The input transfer used in the forward pass.
+            seed: The downstream backward seed (loss on the last stage, transfer + grads otherwise).
 
         Raises:
             ValueError: If a double backward is attempted.
         """
         if microbatch_index in self._cache:
-            raise ValueError("Double backward pass")
+            raise ValueError(f"S{self._stage_idx}B{microbatch_index} double backward")
 
         input_leaves, input_spec = pytree.tree_flatten(inputs)
-        output_grad_leaves = pytree.tree_leaves(outputs_grad) if outputs_grad is not None else None
+        output_leaves, output_grad_leaves = self._seed_leaves(seed)
 
-        if self._stage_idx == 0:
-            self._cache[microbatch_index] = BackwardCacheInputForFull(
-                stage_outputs_or_loss=pytree.tree_leaves(outputs),
-                output_grads=output_grad_leaves,
-                input_values=input_leaves,
-            )
-        else:
+        if self._has_input_peer:
             results = stage_backward_input(
-                outputs=pytree.tree_leaves(outputs),
+                outputs=output_leaves,
                 output_grads=output_grad_leaves,
                 inputs=input_leaves,
                 weights=self._parameters_with_grad(),
             )
 
-            self._cache[microbatch_index] = BackwardCacheInputForWeight(
-                inputs_grad=cast(
-                    dict[str, torch.Tensor],
-                    pytree.tree_unflatten(input_spec, cast(list[torch.Tensor], results.input_grads)),
+            self._cache[microbatch_index] = _BackwardState(
+                sendable_grads=_SendableInputGrads(leaves=results.input_grads, treespec=input_spec),
+                pending_weight=_DeferredWeightBackward(
+                    param_groups=results.param_groups,
+                    ownership_tokens=results.grad_ownership_tokens,
                 ),
-                param_groups=results.param_groups,
-                ownership_tokens=results.grad_ownership_tokens,
+            )
+        else:
+            self._cache[microbatch_index] = _BackwardState(
+                sendable_grads=None,
+                pending_weight=_DeferredFullBackward(
+                    outputs=output_leaves,
+                    output_grads=output_grad_leaves,
+                    inputs=input_leaves,
+                ),
             )
 
     def backward_weight(self, microbatch_index: int):
@@ -238,44 +326,49 @@ class BackwardComputeHandler:
         if microbatch_index not in self._cache:
             raise ValueError(f"S{self._stage_idx}BW{microbatch_index} - weight backward with no input backward before")
 
-        prev_cache = self._cache.pop(microbatch_index)
+        state = self._cache[microbatch_index]
+        pending = state.pending_weight
 
-        match prev_cache:
-            case BackwardCacheInputForFull():
+        match pending:
+            case _DeferredFullBackward():
                 stage_backward_full(
-                    outputs=prev_cache.stage_outputs_or_loss,
-                    output_grads=prev_cache.output_grads,
-                    inputs=prev_cache.input_values,
+                    outputs=pending.outputs,
+                    output_grads=pending.output_grads,
+                    inputs=pending.inputs,
                 )
-            case BackwardCacheInputForWeight():
-                stage_backward_weight(weights=self._parameters_with_grad(), param_groups=prev_cache.param_groups)
-            case _:
-                raise ValueError("Previous backward was not input backward")
+            case _DeferredWeightBackward():
+                stage_backward_weight(weights=self._parameters_with_grad(), param_groups=pending.param_groups)
+            case None:
+                raise ValueError("Previous backward was a full backward, not an input backward")
 
-    def pop_for_sending(self, microbatch_index: int) -> dict[str, torch.Tensor]:
-        """Retrieves the calculated input gradients for a microbatch.
+        state.pending_weight = None
+        self._release_if_complete(microbatch_index)
+
+    def pop_for_sending(self, microbatch_index: int) -> TStageTransfer:
+        """Retrieves the calculated input gradients for a microbatch as a transfer PyTree.
 
         Args:
             microbatch_index: Identifier for the microbatch.
 
         Returns:
-            Dictionary of gradient tensors.
+            The input gradients, shaped like the stage's input transfer.
 
         Raises:
             ValueError: If the required backward pass was not performed or if gradients are missing.
         """
-        cached = self._cache[microbatch_index]
+        state = self._cache[microbatch_index]
 
-        match cached:
-            case BackwardCacheFull():
-                del self._cache[microbatch_index]
-            case BackwardCacheInputForWeight():
-                pass
-            case _:
-                raise ValueError("You should call either backward_full or backward_input before popping cached grad")
+        sendable = state.sendable_grads
+        if sendable is None:
+            raise ValueError("You should call either backward_full or backward_input before popping cached grad")
 
-        for grad_value in cached.inputs_grad.values():
+        for grad_value in sendable.leaves:
             if grad_value is None:
                 raise ValueError("Cannot pop null gradient for sending! Perhaps malformed schedule?")
 
-        return cast(dict[str, torch.Tensor], cached.inputs_grad)
+        full_tree = pytree.tree_unflatten(sendable.treespec, sendable.leaves)
+
+        state.sendable_grads = None
+        self._release_if_complete(microbatch_index)
+
+        return cast(TStageTransfer, full_tree)

--- a/d9d/pipelining/infra/stage/stage.py
+++ b/d9d/pipelining/infra/stage/stage.py
@@ -1,21 +1,37 @@
-from typing import Any
+from typing import Generic, cast
 
 import torch
 import torch.distributed as dist
 from torch import nn
 
-from d9d.pipelining.api import ModuleSupportsPipelining, PipelineStageInfo
+from d9d.core import pytree
+from d9d.pipelining.api import (
+    ModuleSupportsPipelining,
+    PipelineStageInfo,
+    StageBoundary,
+    TPipelineInput,
+    TPipelineOutput,
+    TSharedInput,
+    TStageTransfer,
+)
 
-from .communications import StageCommunicationHandler
-from .computations import BackwardComputeHandler, ForwardComputeHandler
+from .communications import StageReceiver, StageSender
+from .computations import (
+    BackwardComputeHandler,
+    BackwardSeed,
+    BackwardSeedLoss,
+    BackwardSeedTransfer,
+    ForwardComputeHandler,
+)
 
 
-class PipelineStage:
+class PipelineStage(Generic[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]):
     """Represents a single structural stage in a Pipelined Model.
 
-    This class acts as an orchestrator that combines `StageCommunicationHandler` (for I/O)
-    and `Forward/BackwardComputeHandler` (for execution). It abstracts away the complexity
-    of buffer management, distributed communication, and gradient calculation from the scheduler.
+    This class acts as an orchestrator that combines the P2P handlers (`StageReceiver`/`StageSender`
+    for I/O) and the `Forward`/`BackwardComputeHandler` (for execution). It abstracts away the
+    complexity of buffer management, distributed communication, and gradient calculation from the
+    scheduler.
     """
 
     def __init__(
@@ -38,96 +54,154 @@ class PipelineStage:
         self._group = group
         self._stage_to_host_topology = stage_to_host_topology
 
-        self._has_backward = False
+        self._configured = False
 
-        self._forward_comm: StageCommunicationHandler | None = None
-        self._backward_comm: StageCommunicationHandler | None = None
+        self._forward_receiver: StageReceiver[TStageTransfer] | None = None
+        self._forward_sender: StageSender[TStageTransfer] | None = None
+        self._backward_receiver: StageReceiver[TStageTransfer] | None = None
+        self._backward_sender: StageSender[TStageTransfer] | None = None
 
-        self._forward_comp = ForwardComputeHandler(stage_index=info.current_stage, module=module)
-        self._backward_comp = BackwardComputeHandler(stage_index=info.current_stage, module=module)
+        self._forward_comp: ForwardComputeHandler[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput] = (
+            ForwardComputeHandler(stage_index=info.current_stage, module=module)
+        )
+        self._backward_comp: BackwardComputeHandler[TPipelineInput, TStageTransfer] | None = None
 
     @property
     def info(self) -> PipelineStageInfo:
         return self._info
 
-    def configure_buffers(
-        self, has_backward: bool, pipeline_inputs_per_microbatch: tuple[dict[str, torch.Tensor], ...]
-    ):
+    def _peer_global_rank(self, stage_idx: int) -> int:
+        return dist.get_global_rank(self._group, self._stage_to_host_topology[stage_idx])
+
+    def _make_receiver(
+        self,
+        inputs: tuple[TPipelineInput, ...],
+        module: ModuleSupportsPipelining,
+        from_stage: int | None,
+        boundary: StageBoundary,
+        requires_grad: bool,
+    ) -> StageReceiver[TStageTransfer] | None:
+        if from_stage is None:
+            return None
+
+        return StageReceiver(
+            peer_global_rank=self._peer_global_rank(from_stage),
+            spec_per_microbatch=tuple(module.stage_transfer_spec(microbatch, boundary) for microbatch in inputs),
+            group=self._group,
+            requires_grad=requires_grad,
+        )
+
+    def _make_sender(self, to_stage: int | None) -> StageSender[TStageTransfer] | None:
+        if to_stage is None:
+            return None
+
+        return StageSender(peer_global_rank=self._peer_global_rank(to_stage), group=self._group)
+
+    def configure_buffers(self, has_backward: bool, pipeline_inputs_per_microbatch: tuple[TPipelineInput, ...]):
         """Initializes the communication handlers and buffers for the stage.
 
-        This must be called before execution to establish P2P buffer sizes and directions. Input/output
-        shapes are inferred per microbatch, so each microbatch's receive buffers are sized independently
-        and the microbatches in a pack may differ in shape.
+        This must be called before execution to establish P2P buffer sizes and directions. Transfer
+        shapes are inferred per microbatch, so each microbatch's receive buffers are sized
+        independently and the microbatches in a pack may differ in shape.
 
         Args:
             has_backward: Does this pipeline stage should store info for a backward pass
-            pipeline_inputs_per_microbatch: A representative input for each microbatch in the pack.
+            pipeline_inputs_per_microbatch: A ``PipelineInput`` for each microbatch.
 
         Raises:
             TypeError: If the module does not support pipelining.
         """
-        self._has_backward = has_backward
-
         prev_stage_idx = None if self._info.is_current_stage_first else self._info.current_stage - 1
         next_stage_idx = None if self._info.is_current_stage_last else self._info.current_stage + 1
 
-        if not isinstance(self._module, ModuleSupportsPipelining):
+        module = self._module
+        if not isinstance(module, ModuleSupportsPipelining):
             raise TypeError("Module does not implement ModuleSupportsPipelining protocol")
 
-        inputs_meta_per_microbatch = tuple(
-            self._module.infer_stage_inputs_from_pipeline_inputs(microbatch_inputs=microbatch)
-            for microbatch in pipeline_inputs_per_microbatch
+        self._forward_receiver = self._make_receiver(
+            pipeline_inputs_per_microbatch,
+            module,
+            from_stage=prev_stage_idx,
+            boundary=StageBoundary.incoming,
+            requires_grad=has_backward,
         )
-        outputs_meta_per_microbatch = tuple(
-            self._module.infer_stage_outputs_from_pipeline_inputs(microbatch_inputs=microbatch)
-            for microbatch in pipeline_inputs_per_microbatch
-        )
-
-        self._forward_comm = StageCommunicationHandler(
-            name="fwd",
-            stage_index=self._info.current_stage,
-            input_stage_index=prev_stage_idx,
-            input_args_per_microbatch=inputs_meta_per_microbatch,
-            output_stage_index=next_stage_idx,
-            output_args=outputs_meta_per_microbatch[0],
-            group=self._group,
-            stage_idx_to_host_rank=self._stage_to_host_topology,
-        )
-        self._forward_comm.set_input_requires_grad_(requires_grad=has_backward)
+        self._forward_sender = self._make_sender(next_stage_idx)
 
         if has_backward:
-            # for grad - current stage receives OUTPUTS as inputs and sends INPUTS as outputs
-            # because it is reversed forward
-            self._backward_comm = StageCommunicationHandler(
-                name="bwd",
+            self._backward_comp = BackwardComputeHandler(
                 stage_index=self._info.current_stage,
-                input_stage_index=next_stage_idx,
-                input_args_per_microbatch=outputs_meta_per_microbatch,
-                output_stage_index=prev_stage_idx,
-                output_args=inputs_meta_per_microbatch[0],
-                group=self._group,
-                stage_idx_to_host_rank=self._stage_to_host_topology,
+                module=module,
+                has_input_peer=not self._info.is_current_stage_first,
             )
-        else:
-            self._backward_comm = None
+            self._backward_receiver = self._make_receiver(
+                pipeline_inputs_per_microbatch,
+                module,
+                from_stage=next_stage_idx,
+                boundary=StageBoundary.outgoing,
+                requires_grad=False,
+            )
+            self._backward_sender = self._make_sender(prev_stage_idx)
 
-    def set_local_fwd_input(self, inputs: dict[str, torch.Tensor], microbatch_index: int):
+        self._configured = True
+
+    def _require_configured(self):
+        if not self._configured:
+            raise ValueError("You must configure stage buffers first")
+
+    def _require_backward(self) -> BackwardComputeHandler[TPipelineInput, TStageTransfer]:
+        if self._backward_comp is None:
+            raise ValueError("Stage is not configured for a backward pass")
+        return self._backward_comp
+
+    def set_local_fwd_input(self, inputs: TStageTransfer, microbatch_index: int):
         """Sets local forward inputs manually.
 
         Used for the V-shape schedulers.
 
         Raises:
-            ValueError: If the forward communication handler is not configured.
+            ValueError: If the stage is not configured, or has no forward receiver (first stage).
         """
-        if self._forward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        if self._forward_receiver is None:
+            raise ValueError("Stage has no forward receiver")
 
-        self._forward_comm.set_inputs_local(inputs, microbatch_index)
+        self._forward_receiver.set_inputs_local(inputs, microbatch_index)
 
-    def get_local_fwd_output(self, microbatch_index: int) -> dict[str, torch.Tensor]:
-        return self._forward_comp.get_outputs(microbatch_index)
+    def get_produced_transfer(self, microbatch_index: int) -> TStageTransfer:
+        """Returns the ``StageTransfer`` this (non-last) stage produced, to hand to the next stage.
 
-    def pop_local_bwd_output(self, microbatch_index: int) -> dict[str, torch.Tensor]:
+        Args:
+            microbatch_index: The microbatch identifier.
+
+        Returns:
+            The produced ``StageTransfer``.
+
+        Raises:
+            ValueError: If called on the last stage, which produces a ``PipelineOutput`` instead.
+        """
+        if self._info.is_current_stage_last:
+            raise ValueError("The last stage produces a PipelineOutput, not a StageTransfer")
+
+        return cast(TStageTransfer, self._forward_comp.get_outputs(microbatch_index))
+
+    def get_pipeline_output(self, microbatch_index: int) -> TPipelineOutput:
+        """Returns the ``PipelineOutput`` this (last) stage produced, to hand to the callback.
+
+        Args:
+            microbatch_index: The microbatch identifier.
+
+        Returns:
+            The produced ``PipelineOutput``.
+
+        Raises:
+            ValueError: If called on a non-last stage, which produces a ``StageTransfer`` instead.
+        """
+        if not self._info.is_current_stage_last:
+            raise ValueError("Only the last stage produces a PipelineOutput")
+
+        return cast(TPipelineOutput, self._forward_comp.get_outputs(microbatch_index))
+
+    def pop_local_bwd_output(self, microbatch_index: int) -> TStageTransfer:
         """Retrieves local backward outputs (gradients).
 
         Returns:
@@ -136,94 +210,91 @@ class PipelineStage:
         Raises:
             ValueError: If the stage is not configured for backward passes.
         """
-        if not self._has_backward:
-            raise ValueError()
+        self._require_configured()
+        backward_comp = self._require_backward()
 
-        return self._backward_comp.pop_for_sending(microbatch_index)
+        return backward_comp.pop_for_sending(microbatch_index)
 
-    def set_local_bwd_input(self, inputs: dict[str, torch.Tensor], microbatch_index: int):
+    def set_local_bwd_input(self, inputs: TStageTransfer, microbatch_index: int):
         """Sets local backward inputs (output gradients) manually.
 
         Raises:
-            ValueError: If the stage is not configured for backward passes or if buffers are not initialized.
+            ValueError: If the stage is not configured for backward passes, or has no backward
+                receiver (last stage).
         """
-        if not self._has_backward:
-            raise ValueError()
+        self._require_configured()
+        self._require_backward()
+        if self._backward_receiver is None:
+            raise ValueError("Stage has no backward receiver (last stage is seeded from the loss)")
 
-        if self._backward_comm is None:
-            raise ValueError("You must configure stage buffers first")
-
-        self._backward_comm.set_inputs_local(inputs, microbatch_index)
+        self._backward_receiver.set_inputs_local(inputs, microbatch_index)
 
     def get_fwd_recv_ops(self, microbatch_index: int) -> list[dist.P2POp]:
         """Returns P2P ops to receive forward inputs for the given microbatch.
 
         Returns:
-            The list of P2P operations.
+            The list of P2P operations (empty if this stage has no forward receiver).
 
         Raises:
-            ValueError: If the forward communication handler is not configured.
+            ValueError: If the stage is not configured.
         """
-        if self._forward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        if self._forward_receiver is None:
+            return []
 
-        return self._forward_comm.create_receive_ops(microbatch_index)
+        return self._forward_receiver.receive(microbatch_index)
 
     def get_fwd_send_ops(self, microbatch_index: int) -> list[dist.P2POp]:
         """Returns P2P ops to send forward outputs for the given microbatch.
 
         Returns:
-            The list of P2P operations.
+            The list of P2P operations (empty if this stage has no forward sender).
 
         Raises:
-            ValueError: If the forward communication handler is not configured.
+            ValueError: If the stage is not configured.
         """
-        if self._forward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        if self._forward_sender is None:
+            return []
 
-        fwd_result = self._forward_comp.get_outputs(microbatch_index)
-        return self._forward_comm.create_send_ops(fwd_result)
+        return self._forward_sender.send(self.get_produced_transfer(microbatch_index))
 
     def get_bwd_recv_ops(self, microbatch_index: int) -> list[dist.P2POp]:
         """Returns P2P ops to receive backward gradients for the given microbatch.
 
         Returns:
-            The list of P2P operations.
-
-        Raises:
-            ValueError: If the backward communication handler is not configured.
+            The list of P2P operations (empty if this stage has no backward receiver).
         """
-        if not self._has_backward:
+        if self._backward_comp is None:
             return []
 
-        if self._backward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        if self._backward_receiver is None:
+            return []
 
-        return self._backward_comm.create_receive_ops(microbatch_index)
+        return self._backward_receiver.receive(microbatch_index)
 
     def get_bwd_send_ops(self, microbatch_index: int) -> list[dist.P2POp]:
         """Returns P2P ops to send backward gradients for the given microbatch.
 
         Returns:
-            The list of P2P operations.
-
-        Raises:
-            ValueError: If the backward communication handler is not configured.
+            The list of P2P operations (empty if this stage has no backward sender).
         """
-        if not self._has_backward:
+        if self._backward_comp is None:
             return []
 
-        if self._backward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        if self._backward_sender is None:
+            return []
 
         bwd_result = self._backward_comp.pop_for_sending(microbatch_index)
-        return self._backward_comm.create_send_ops(bwd_result)
+        return self._backward_sender.send(bwd_result)
 
     def forward_one_chunk(
         self,
         microbatch_index: int,
-        pipeline_inputs: dict[str, torch.Tensor],
-        pipeline_kwargs: dict[str, Any] | None = None,
+        pipeline_inputs: TPipelineInput,
+        pipeline_shared: TSharedInput,
     ):
         """Executes a forward pass for a single microbatch chunk.
 
@@ -232,23 +303,21 @@ class PipelineStage:
 
         Args:
             microbatch_index: The microbatch index.
-            pipeline_inputs: Inputs provided locally (only used if this is the first stage).
-            pipeline_kwargs: Additional arguments for the module.
+            pipeline_inputs: The ``PipelineInput`` provided locally (only used if this is the first
+                stage).
+            pipeline_shared: The ``SharedInput`` passed to every stage.
 
         Raises:
-            ValueError: If the forward communication handler is not configured.
+            ValueError: If the stage is not configured.
         """
-        if self._forward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
 
-        if self._info.is_current_stage_first:
+        if self._forward_receiver is None:
             inputs = pipeline_inputs
         else:
-            inputs = self._forward_comm.get_inputs(microbatch_index)
+            inputs = self._forward_receiver.pop_inputs(microbatch_index)
 
-        kwargs = pipeline_kwargs or {}
-
-        self._forward_comp.run(microbatch_index=microbatch_index, inputs=inputs, kwargs=kwargs)
+        self._forward_comp.run(microbatch_index=microbatch_index, inputs=inputs, shared=pipeline_shared)
 
     def backward_one_chunk(self, microbatch_index: int, loss: torch.Tensor | None = None, full_backward: bool = True):
         """Executes a backward pass for a single microbatch chunk.
@@ -262,39 +331,32 @@ class PipelineStage:
             full_backward: If True, computes grads for inputs and weights. If False, only for inputs.
 
         Raises:
-            ValueError: If the stage is not configured for backward passes or if buffers are not initialized.
+            ValueError: If the stage is not configured for backward passes.
         """
-        if not self._has_backward:
-            raise ValueError()
-
-        if self._backward_comm is None:
-            raise ValueError("You must configure stage buffers first")
+        self._require_configured()
+        backward_comp = self._require_backward()
 
         inputs, fwd_outputs = self._forward_comp.pop_inputs_outputs(microbatch_index)
 
-        outputs: dict[str, torch.Tensor]
-        outputs_grad: dict[str, torch.Tensor] | None
-
-        if self._info.is_current_stage_last:
+        seed: BackwardSeed[TStageTransfer]
+        if self._backward_receiver is None:
+            # last stage: the output stays in the pipeline, backward is seeded from the loss
             if loss is None:
                 raise ValueError("Cannot perform backward on last stage without loss specified")
-            outputs = {"loss": loss}
-            outputs_grad = None
+            seed = BackwardSeedLoss(loss=loss)
         else:
-            outputs = fwd_outputs
-            outputs_grad = self._backward_comm.get_inputs(microbatch_index)
+            seed = BackwardSeedTransfer(
+                outputs=cast(TStageTransfer, fwd_outputs),
+                output_grads=self._backward_receiver.pop_inputs(microbatch_index),
+            )
 
         if full_backward:
-            self._backward_comp.backward_full(
-                microbatch_index=microbatch_index, inputs=inputs, outputs=outputs, outputs_grad=outputs_grad
-            )
+            backward_comp.backward_full(microbatch_index=microbatch_index, inputs=inputs, seed=seed)
         else:
-            self._backward_comp.backward_input(
-                microbatch_index=microbatch_index, inputs=inputs, outputs=outputs, outputs_grad=outputs_grad
-            )
+            backward_comp.backward_input(microbatch_index=microbatch_index, inputs=inputs, seed=seed)
 
         if self._info.is_current_stage_last and not self._info.is_current_stage_first:
-            for t in fwd_outputs.values():
+            for t in pytree.tree_leaves(fwd_outputs):
                 if not t._is_view():  # noqa: SLF001
                     t.detach_()
 
@@ -310,14 +372,14 @@ class PipelineStage:
         Raises:
             ValueError: If the stage is not configured for backward passes.
         """
-        if not self._has_backward:
-            raise ValueError()
+        self._require_configured()
+        backward_comp = self._require_backward()
 
-        self._backward_comp.backward_weight(microbatch_index=microbatch_index)
+        backward_comp.backward_weight(microbatch_index=microbatch_index)
 
     def reset(self):
         """Resets the internal state of communication handlers, clearing gradients on buffers."""
-        if self._forward_comm is not None:
-            self._forward_comm.reset()
-        if self._backward_comm is not None:
-            self._backward_comm.reset()
+        if self._forward_receiver is not None:
+            self._forward_receiver.reset()
+        if self._backward_receiver is not None:
+            self._backward_receiver.reset()

--- a/deps/0010-dep-pipelining-pytree-io.md
+++ b/deps/0010-dep-pipelining-pytree-io.md
@@ -1,0 +1,172 @@
+---
+DEP: 0010
+Title: Typed PyTree IO for Pipelining and Tasks
+Author: Maksim Afanasyev @mrapplexz
+Status: Draft
+Type: Feature
+Created: 2026-07-10
+---
+
+# Typed PyTree IO for Pipelining and Tasks
+
+## Abstract
+
+The pipelining engine and the `TrainTask`/`InferenceTask` APIs move all data across pipeline
+boundaries as `dict[str, torch.Tensor]`. A single dict type is overloaded to mean four distinct
+things — the input to the first stage, the payload transferred between adjacent stages, the
+output of the last stage, and the arguments broadcast to every stage — with no type-level
+distinction. String keys simultaneously act as `forward` parameter names (`**inputs` splat),
+the P2P wire ordering (sorted-by-name pairing), the gradient-routing keys, and the loss field
+names.
+
+This DEP replaces stringly-typed dict IO with four explicitly-named, generic PyTree types.
+Models declare their IO as dataclasses; transport becomes structure-driven instead of
+name-driven; and the four roles become distinct, type-checked entities.
+
+## Motivation
+
+The overloading described above produces three concrete failures, anchored in today's code:
+
+- **Roles documented in prose.** `BuildForwardInputsResult` must explain input vs
+  kwargs vs state in its docstring because the signatures cannot.
+- **Boilerplate `forward`.** One class serves every stage position, so `forward` lists every
+  tensor as `... | None = None` and branches on which args are `None` — an implicit invariant.
+- **Confusing spec inference.** `ModuleSupportsPipelining` requires two methods returning
+  `dict[str, TensorSpec]` that duplicate most of their logic, and the untyped dict cannot be
+  checked against the actual transfer structure.
+
+## Design Proposal
+
+### The four roles, named
+
+| Role                                                        | Type             | Transferred over P2P? |
+|-------------------------------------------------------------|------------------|-----------------------|
+| Input to the first stage (built by the task)                | `PipelineInput`  | no                    |
+| Payload between adjacent stages (out of *N* == in of *N+1*) | `StageTransfer`  | yes                   |
+| Output of the last stage (to loss/result callback)          | `PipelineOutput` | no                    |
+| Value passed to *every* stage, rebuilt locally per rank     | `SharedInput`    | no                    |
+
+Each is an arbitrary PyTree; dataclasses are the recommended form. Only `StageTransfer` needs a
+`TensorSpec` — it is the only thing crossing the wire, so only its receive buffer must be sized
+ahead of the forward pass.
+
+### Model-facing contract
+
+A stage knows its position (`PipelineStageInfo` at construction), so it branches on explicit
+position, never on `None`-sniffing. `ModuleSupportsPipelining` becomes generic over the four
+types:
+
+```python
+class StageBoundary(enum.Enum):
+    incoming = "incoming"   # StageTransfer received from stage N-1
+    outgoing = "outgoing"   # StageTransfer sent to stage N+1
+
+
+@typing.runtime_checkable
+class ModuleSupportsPipelining(
+    typing.Protocol[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]
+):
+    def forward(
+        self,
+        inputs: TPipelineInput | TStageTransfer,   # PipelineInput iff first stage, else StageTransfer
+        shared: TSharedInput,
+    ) -> TStageTransfer | TPipelineOutput:         # PipelineOutput iff last stage, else StageTransfer
+        ...
+
+    def stage_transfer_spec(
+        self, pipeline_input: TPipelineInput, boundary: StageBoundary
+    ) -> PyTree[TensorSpec]:
+        ...
+```
+
+The spec must be structurally identical to `TStageTransfer`.
+
+### Structure-driven transport
+
+Because stage *N*'s `outgoing` and stage *N+1*'s `incoming` are the **same dataclass type**,
+`pytree.tree_flatten` yields identical leaf orderings on both ends. Sender and receiver agree on
+wire order by construction, so no shape/name handshake is needed.
+
+- **Send**: flatten the outgoing `StageTransfer`; `isend` leaves in order.
+- **Receive**: flatten `stage_transfer_spec(..., incoming)`
+  to ordered `TensorSpec` leaves + treespec; allocate a buffer per leaf; `tree_unflatten` back
+  into a `StageTransfer` for `forward`.
+- **Backward** already uses `d9d.core.pytree`.
+- **Forward**: drop the `**inputs` splat and the `Mapping` check; call `module(inputs, shared)`.
+
+### Downstream API changes
+
+- `BuildForwardInputsResult` → `Generic[TPipelineInput, TSharedInput, TState]` with
+  `input`/`shared`/`state` (was `inputs`/`kwargs` dicts).
+- `ComputeLossContext.pipeline_results` / `ProcessOutputsContext.pipeline_results` →
+  `TPipelineOutput`.
+- `PipelineLossFn` / `PipelineResultFn` take `TPipelineOutput`.
+- `PipelineSchedule.step` generalizes to per-microbatch `TPipelineInput`/`TSharedInput`.
+- The four type parameters thread through the protocol, `PipelineSchedule`, task base classes,
+  and loss/result contexts. Pure tensor-shuffling internals stay on `PyTree`/leaf lists.
+
+## Usage
+
+```python
+TLeaf = TypeVar("TLeaf")
+
+@dataclasses.dataclass
+class CausalLMInput:                       # PipelineInput
+    input_ids: torch.Tensor
+
+@dataclasses.dataclass
+class Qwen3Transfer(Generic[TLeaf]):       # StageTransfer, generic over its leaf type
+    hidden_states: TLeaf
+
+@dataclasses.dataclass
+class CausalLMShared:                      # SharedInput
+    position_ids: torch.Tensor
+    labels: torch.Tensor | None = None
+
+@dataclasses.dataclass
+class CausalLMOutput:                      # PipelineOutput
+    logps: torch.Tensor
+
+
+class Qwen3DenseForCausalLM(
+    nn.Module, ModuleLateInit,
+    ModuleSupportsPipelining[CausalLMInput, Qwen3Transfer[torch.Tensor], CausalLMShared, CausalLMOutput],
+):
+    def forward(
+        self, inputs: CausalLMInput | Qwen3Transfer[torch.Tensor], shared: CausalLMShared
+    ) -> CausalLMOutput | Qwen3Transfer[torch.Tensor]:
+        if self._stage.is_current_stage_first:
+            hidden = self.model.embed(inputs.input_ids)
+        else:
+            hidden = inputs.hidden_states
+        hidden = self.model.layers(hidden, shared)
+        if self._stage.is_current_stage_last:
+            return CausalLMOutput(logps=self.lm_head(hidden, labels=shared.labels))
+        else:
+            return Qwen3Transfer(hidden_states=hidden)
+
+    def stage_transfer_spec(
+        self, pipeline_input: CausalLMInput, boundary: StageBoundary
+    ) -> Qwen3Transfer[TensorSpec]:
+        b, s = pipeline_input.input_ids.shape
+        return Qwen3Transfer(hidden_states=TensorSpec(shape=(b, s, self._hidden_size), dtype=self._dtype))
+```
+
+The task then builds `PipelineInput`/`SharedInput` and reads `ctx.pipeline_results.logps` by
+attribute — no dict keys.
+
+## Backward Compatibility
+
+Breaks public API.
+
+## Alternatives Considered
+
+1. **Keep dicts, add name-matching validation.** Leaves the
+   overloaded type, the splat, and the six-optional `forward`. Symptom, not disease.
+2. **`TypedDict` instead of dataclasses.** Still a runtime `dict`,
+   cannot express the `PipelineInput | StageTransfer` union cleanly.
+3. **Trace `forward` under `FakeTensorMode` to derive transfer shapes**, dropping
+   `stage_transfer_spec` entirely. Rejected: fake-tensor tracing still executes the full Python
+   body of every stage (layer loops, routing branches) on CPU, re-run on each shape change — far
+   more expensive than the cheap shape arithmetic an explicit spec method does. The explicit
+   method is the point: it sizes buffers without running the body.

--- a/docs/loop/interfaces/task.md
+++ b/docs/loop/interfaces/task.md
@@ -43,14 +43,23 @@ It is designed to handle the **forward-only** flow, processing the raw tensors s
 
 You may note that `batch` is only accessible in `build_forward_inputs(...)`, but not in the later stages. Don't worry!
 
-Each task declares a **state** type (`TState`, the second type parameter of `TrainTask` / `InferenceTask`) — a PyTree, typically a `TypedDict`, carrying any side-data from `build_forward_inputs` to the later stages of the **same microbatch** (labels, masks, token counts, …). `build_forward_inputs` returns it; `compute_loss` / `process_outputs` / `update_metrics` read it back, fully typed. Tasks that carry nothing use `None`.
+The **state** carries side-data from `build_forward_inputs` to the later stages of the **same microbatch** — labels, masks, token counts, or anything else the model forward does not return but the loss or metrics need.
+
+It is declared by `TState`, the last type parameter of `TrainTask` / `InferenceTask`. `TState` is any PyTree, so you can use whatever shape fits:
+
+* a **dataclass** — when you want attribute access and strict typing;
+* a **`TypedDict`** — when you prefer dict access but still want keys checked;
+* a **plain `dict`** — for quick, untyped side-data;
+* **`None`** — for tasks that carry nothing.
+
+`build_forward_inputs` returns the state; `compute_loss` / `process_outputs` / `update_metrics` read it back, fully typed.
 
 ```python
 class MyState(TypedDict):
     target: torch.Tensor
 
 # in build_forward_inputs:
-return BuildForwardInputsResult(inputs=..., kwargs=..., state=MyState(target=ctx.batch["target"]))
+return BuildForwardInputsResult(input=..., shared=..., state=MyState(target=ctx.batch["target"]))
 
 # later, in update_metrics / compute_loss:
 metrics["accuracy"].update(ctx.state["target"])  # ctx.state is typed as MyState
@@ -60,6 +69,17 @@ Tensors stored in the state are detached from the autograd graph automatically, 
 
 ## Example Implementation
 
+A task's IO is typed by the same four PyTree roles the model pipeline uses (see [Pipeline
+Parallelism](../models/pipeline_parallelism.md)). `TrainTask` is generic over
+`[TBatch, TPipelineInput, TSharedInput, TPipelineOutput, TState]`:
+
+* `TPipelineInput` — the `PipelineInput` fed to the **first** stage (built here).
+* `TSharedInput` — the `SharedInput` broadcast to **every** stage.
+* `TPipelineOutput` — the `PipelineOutput` produced by the **last** stage; read by attribute in `compute_loss`.
+
+`build_forward_inputs` returns a `BuildForwardInputsResult` with `input` / `shared` / `state`
+fields — no dict keys.
+
 ```python
 import torch
 from typing import TypedDict
@@ -67,40 +87,42 @@ from typing import TypedDict
 from d9d.core.dist_context import DistributedContext
 from d9d.core.types import ScalarTree
 from d9d.module.block.head import LM_IGNORE_INDEX
+from d9d.module.model.io import SequenceCausalLMOutput, SequenceCausalLMShared, SequenceInput, SequenceShared
 from d9d.loop.control import *
 
 
-class SFTState(TypedDict):
+class SFTState(TypedDict):  # it also could be a dataclass
     labels: torch.Tensor
 
 
-class SFTTask(TrainTask[dict[str, torch.Tensor], SFTState]):
+class SFTTask(
+    TrainTask[dict[str, torch.Tensor], SequenceInput, SequenceCausalLMShared, SequenceCausalLMOutput, SFTState]
+):
     def __init__(self, dist_ctx: DistributedContext):
         self._dist_ctx = dist_ctx
 
-    def build_forward_inputs(self, ctx: BuildForwardInputsContext) -> BuildForwardInputsResult[SFTState]:
+    def build_forward_inputs(
+        self, ctx: BuildForwardInputsContext
+    ) -> BuildForwardInputsResult[SequenceInput, SequenceCausalLMShared, SFTState]:
         # ctx.batch contains the output of the Collator.
 
-        # Return inputs for model.forward() plus the typed side-data for later stages.
-        # inputs are only for the first pipeline stage
-        # kwargs are the same for all the pipeline stages
+        # Return the PipelineInput, the SharedInput and the typed
+        # side-data carried to loss computation for this same microbatch.
         return BuildForwardInputsResult(
-            inputs={
-                "input_ids": ctx.batch["input_ids"]
-            },
-            kwargs={
-                "labels": ctx.batch["labels"],
-                "position_ids": ctx.batch["position_ids"]
-            },
+            input=SequenceInput(input_ids=ctx.batch["input_ids"]),
+            shared=SequenceCausalLMShared(
+                sequence=SequenceShared(position_ids=ctx.batch["position_ids"]),
+                labels=ctx.batch["labels"],
+            ),
             state=SFTState(labels=ctx.batch["labels"]),
         )
 
     def dump_hparams(self) -> ScalarTree:
         return super().dump_hparams()
 
-    def compute_loss(self, ctx: ComputeLossContext[SFTState]) -> ComputeLossResult:
+    def compute_loss(self, ctx: ComputeLossContext[SequenceCausalLMOutput, SFTState]) -> ComputeLossResult:
         # Retrieve log_probs calculated by the model pipeline
-        logps = ctx.pipeline_results["logps"]
+        logps = ctx.pipeline_results.logps
 
         # Calculate number of valid tokens (ignoring the -100 padding)
         # This is crucial for variable length batches.

--- a/docs/models/pipeline_parallelism.md
+++ b/docs/models/pipeline_parallelism.md
@@ -6,7 +6,7 @@ d9d implements a modern, highly modular pipelining engine designed for performan
 
 ### Dynamic Shapes & Algorithmic Shape Inference
 
-To run P2P (Point-to-Point) communication, the receiver must know the shape of the incoming tensor to pre-allocate buffers. d9d asks your model to implement a lightweight protocol (`ModuleSupportsPipelining`) to calculate stage input and output shapes from batch input shapes mathematically, without performing a heavy forward pass or doing a distributed graph tracing.
+To run P2P (Point-to-Point) communication, the receiver must know the shape of the incoming tensor to pre-allocate buffers. d9d asks your model to implement a lightweight protocol (`ModuleSupportsPipelining`) to calculate the shape of the payload transferred between stages mathematically, without performing a heavy forward pass or doing a distributed graph tracing.
 
 This allows supporting **Dynamic Shapes** (e.g., varying sequence lengths) efficiently across runs.
 
@@ -23,101 +23,131 @@ In d9d, models are **Pipeline-Aware**. Each pipeline rank constructs **only** th
 
 ## Making Models Compatible
 
+### The Four IO Roles
+
+A pipelined model moves data across stage boundaries as four **explicitly-named, generic PyTree
+types** (dataclasses are the recommended form):
+
+| Role             | Meaning                                                     | Crosses P2P? |
+|------------------|-------------------------------------------------------------|--------------|
+| `PipelineInput`  | Input to the **first** stage (built by the task)            | no           |
+| `StageTransfer`  | Payload between adjacent stages (out of *N* == in of *N+1*) | **yes**      |
+| `PipelineOutput` | Output of the **last** stage (to loss / result callback)    | no           |
+| `SharedInput`    | Value passed to **every** stage, rebuilt locally per rank   | no           |
+
+Only `StageTransfer` crosses the wire, so it is the only role that needs a `TensorSpec`.
+
 ### The Protocol
 
-**Implementing the Protocol**
+To use Pipeline Parallelism, your model implements
+`d9d.pipelining.api.ModuleSupportsPipelining[TPipelineInput, TStageTransfer, TSharedInput, TPipelineOutput]`:
 
-To use Pipeline Parallelism in d9d, your model must implement the `d9d.pipelining.api.ModuleSupportsPipelining` protocol to allow the framework to manage memory and buffer allocations.
+* **`forward(inputs, shared)`** — `inputs` is the `PipelineInput` on the first stage and the incoming
+  `StageTransfer` otherwise; it returns the outgoing `StageTransfer` on non-last stages and the
+  `PipelineOutput` on the last stage. The stage knows its position from the `PipelineStageInfo` it
+  received at construction, so it branches on `is_current_stage_first` / `is_current_stage_last`
+  explicitly.
+* **`stage_transfer_spec(pipeline_input, boundary)`** — returns a PyTree **structurally identical to
+  `StageTransfer`** with every tensor leaf replaced by a `TensorSpec`. The `boundary`
+  (`StageBoundary.incoming` / `outgoing`) selects which inter-stage edge to size.
 
-**Forward Compatibility**
-
-* Pipelined models currently only support **outputting a dictionary** (`dict[str, torch.Tensor]`). However, we plan to support arbitrary PyTrees in further releases. The keys in the dictionary returned by your `forward` method must strictly match the keys in the dictionary calculated by `infer_stage_outputs_from_pipeline_inputs`. 
-* The named arguments accepted by your `forward` method must strictly match the `infer_stage_inputs_from_pipeline_inputs`. 
-
-This allows the communication handler to map tensor names to P2P buffers deterministically.
+Because stage *N*'s `outgoing` transfer and stage *N+1*'s `incoming` transfer are the **same
+dataclass type**, `pytree.tree_flatten` yields identical leaf orderings on both ends. Sender and
+receiver therefore agree on the wire order **by construction** — no name/shape handshake is needed.
 
 ### Example
 
 Below is a skeleton of a Transformer-like model implemented for d9d pipelining.
 
 ```python
+import dataclasses
 import torch
 from torch import nn
-from d9d.pipelining.api import PipelineStageInfo, TensorSpec, distribute_layers_for_pipeline_stage
+from d9d.pipelining.api import (
+    ModuleSupportsPipelining,
+    PipelineStageInfo,
+    StageBoundary,
+    TensorSpec,
+    distribute_layers_for_pipeline_stage,
+)
 
-class MyModelChunk(nn.Module):
+
+@dataclasses.dataclass
+class MyInput:              # PipelineInput
+    input_ids: torch.Tensor
+
+
+@dataclasses.dataclass
+class MyTransfer:           # StageTransfer (the only role crossing P2P)
+    hidden_states: torch.Tensor
+
+
+@dataclasses.dataclass
+class MyShared:             # SharedInput (broadcast to every stage)
+    position_ids: torch.Tensor
+
+
+@dataclasses.dataclass
+class MyOutput:             # PipelineOutput
+    logits: torch.Tensor
+
+
+class MyModelChunk(
+    nn.Module,
+    ModuleSupportsPipelining[MyInput, MyTransfer, MyShared, MyOutput],
+):
     def __init__(self, stage: PipelineStageInfo, config):
         super().__init__()
         self.stage = stage
         self.config = config
-        
+
         # 1. Determine what layers live here
         self.start_layer, self.end_layer = distribute_layers_for_pipeline_stage(
             config.n_layers, num_virtual_layers_pre=1, num_virtual_layers_post=1, stage=stage
         )
-        
+
         # 2. Build sub-modules (using ModuleDict - for compatibility)
         self.layers = nn.ModuleDict({
-            str(layer): TransformerBlock(...) 
+            str(layer): TransformerBlock(...)
             for layer in range(self.start_layer, self.end_layer)
         })
-        
+
         # Only build embeddings on first stage
         if stage.is_current_stage_first:
             self.embed = nn.Embedding(...)
-            
+
         # Only build head on last stage
         if stage.is_current_stage_last:
             self.head = nn.Linear(...)
 
-    def forward(self, input_ids=None, hidden_states=None):        
-        # Run embeddings only on first stage
+    def forward(self, inputs: MyInput | MyTransfer, shared: MyShared) -> MyTransfer | MyOutput:
+        # Branch on the stage position, never on which argument is None.
         if self.stage.is_current_stage_first:
-            x = self.embed(input_ids)
+            x = self.embed(inputs.input_ids)
         else:
-            x = hidden_states
-            
+            x = inputs.hidden_states
+
         # Run local layers
         for layer_idx in range(self.start_layer, self.end_layer):
             x = self.layers[str(layer_idx)](x)
-        
-        outputs = {
-            "hidden_states": x
-        }
-        
-        # Last stage logic
+
+        # Last stage produces the PipelineOutput; everyone else produces a StageTransfer.
         if self.stage.is_current_stage_last:
-            logits = self.head(x)
-            outputs['logits'] = logits
-        
-        return outputs
+            return MyOutput(logits=self.head(x))
+        return MyTransfer(hidden_states=x)
 
     # --- Protocol Implementation ---
-    # These receive a single representative microbatch (not a global batch), so shapes are used as-is,
-    # and return TensorSpec descriptors (shape/dtype/layout) — no tensors are allocated.
-
-    def infer_stage_inputs_from_pipeline_inputs(self, microbatch_inputs: dict[str, torch.Tensor]):
-        micro_batch_size = microbatch_inputs['input_ids'].shape[0]
-        seq_len = microbatch_inputs['input_ids'].shape[1]
-        
-        if self.stage.is_current_stage_first:
-            # First stage receives raw input IDs
-            return {"input_ids": TensorSpec(shape=(micro_batch_size, seq_len), dtype=torch.long)}
-        else:
-            # Intermediate stages receive hidden states from previous stage
-            return {"hidden_states": TensorSpec(shape=(micro_batch_size, seq_len, self.hidden_dim), dtype=torch.bfloat16)}
-
-    def infer_stage_outputs_from_pipeline_inputs(self, microbatch_inputs: dict[str, torch.Tensor]):
-        micro_batch_size = microbatch_inputs['input_ids'].shape[0]
-        seq_len = microbatch_inputs['input_ids'].shape[1]
-        
-        outputs = {"hidden_states": TensorSpec(shape=(micro_batch_size, seq_len, self.config.hidden_dim), dtype=torch.bfloat16)}
-        
-        if self.stage.is_current_stage_last:
-            # Last stage outputs logits too
-            outputs["logits"] = TensorSpec(shape=(micro_batch_size, seq_len, self.config.vocab_size), dtype=torch.bfloat16)
-        
-        return outputs
+    # Receives a single representative microbatch of PipelineInput (not a global batch), so shapes are
+    # used as-is, and returns a StageTransfer of TensorSpec descriptors — no tensors are allocated.
+    # The engine never calls this for the first stage's `incoming` nor the last stage's `outgoing`
+    # edge, so terminal boundaries need no special-casing.
+    def stage_transfer_spec(self, pipeline_input: MyInput, boundary: StageBoundary) -> MyTransfer:
+        micro_batch_size, seq_len = pipeline_input.input_ids.shape
+        return MyTransfer(
+            hidden_states=TensorSpec(
+                shape=(micro_batch_size, seq_len, self.config.hidden_dim), dtype=torch.bfloat16
+            )
+        )
 ```
 
 ## Using the Pipeline
@@ -159,15 +189,16 @@ from d9d.core.dist_context import DistributedContext
 from d9d.pipelining.factory import build_schedule, PipelineSchedule1F1BConfig
 
 
-# 0. Define an object that manages loss calculation per microbatch
-class PipelineLossHandler:
+# 0. Define an object that manages loss calculation per microbatch. It receives the PipelineOutput
+#    produced by the last stage and reads its fields by attribute.
+class MyLossHandler:
     def __init__(self, targets_microbatches: list[Tensor]):
         self._targets = targets_microbatches
 
-    def compute_loss(self, outputs: dict[str, Tensor], microbatch_idx: int):
+    def compute_loss(self, outputs: MyOutput, microbatch_idx: int):
         # Implement any custom logic here
         current_target = self._targets[microbatch_idx]
-        return F.cross_entropy(outputs['logits'].view(-1, outputs['logits'].shape[-1]), current_target.view(-1))
+        return F.cross_entropy(outputs.logits.view(-1, outputs.logits.shape[-1]), current_target.view(-1))
 
 
 # 1. Define configuration
@@ -178,13 +209,14 @@ schedule_config = PipelineSchedule1F1BConfig(
     zero_bubble=True  # Enable ZB1P optimization
 )
 
-# 2. Build the per-microbatch inputs (the "pack"). The number of microbatches is decided here, per step.
-inputs_microbatches = tuple({"input_ids": mb} for mb in my_input_microbatches)
-kwargs_microbatches = tuple({} for _ in inputs_microbatches)
+# 2. Build the per-microbatch inputs (the "pack"). The number of microbatches is decided here, per
+#    step. Each stage receives one PipelineInput and one SharedInput per microbatch.
+inputs_microbatches = tuple(MyInput(input_ids=mb) for mb in my_input_microbatches)
+shared_microbatches = tuple(MyShared(position_ids=pos) for pos in my_position_microbatches)
 targets_microbatches = [...]  # one target tensor per microbatch
 
 # 3. Build the schedule and model shards (the callback is supplied per step, not here)
-loss_handler = PipelineLossHandler(targets_microbatches)
+loss_handler = MyLossHandler(targets_microbatches)
 schedule_info, modules = build_schedule(
     dist_context=dist_context,
     schedule_config=schedule_config,
@@ -195,7 +227,7 @@ schedule_info, modules = build_schedule(
 # The callback is passed to each step, so it can close over per-step data (here, the targets).
 schedule_info.schedule.step(
     inputs_microbatches=inputs_microbatches,
-    kwargs_microbatches=kwargs_microbatches,
+    shared_microbatches=shared_microbatches,
     callback=loss_handler.compute_loss,
 )
 ```

--- a/example/qwen3_moe/calculate_perplexity.py
+++ b/example/qwen3_moe/calculate_perplexity.py
@@ -29,6 +29,7 @@ from d9d.loop.run import InferenceConfigurator
 from d9d.model_state.mapper.adapters import identity_mapper_from_module
 from d9d.module.block.head import LM_IGNORE_INDEX
 from d9d.module.block.hidden_states_aggregator import HiddenStatesAggregationMode
+from d9d.module.model.io import SequenceCausalLMOutput, SequenceCausalLMShared, SequenceInput, SequenceShared
 from d9d.module.model.qwen3_moe import Qwen3MoEForCausalLM, Qwen3MoEForCausalLMParameters
 from d9d.module.parallelism.model.qwen3_moe import parallelize_qwen3_moe_for_causal_lm
 from pydantic import BaseModel
@@ -211,30 +212,32 @@ class PerplexityState(TypedDict):
     labels: torch.Tensor
 
 
-class PerplexityTask(InferenceTask[dict[str, torch.Tensor], PerplexityState]):
+class PerplexityTask(
+    InferenceTask[
+        dict[str, torch.Tensor], SequenceInput, SequenceCausalLMShared, SequenceCausalLMOutput, PerplexityState
+    ]
+):
     def __init__(self, dist_ctx: DistributedContext):
         self._dist_ctx = dist_ctx
         self._cache: list[torch.Tensor] = []
 
-    def build_forward_inputs(self, ctx: BuildForwardInputsContext) -> BuildForwardInputsResult[PerplexityState]:
+    def build_forward_inputs(
+        self, ctx: BuildForwardInputsContext
+    ) -> BuildForwardInputsResult[SequenceInput, SequenceCausalLMShared, PerplexityState]:
         # ctx.batch contains the output of the Collator.
 
-        # Return inputs for model.forward() plus the typed side-data for output processing.
-        # inputs are only for the first pipeline stage
-        # kwargs are the same for all the pipeline stages
+        # Return the pipeline input (first stage only) plus the shared input (every stage) and the
+        # typed side-data carried to output processing.
         return BuildForwardInputsResult(
-            inputs={
-                "input_ids": ctx.batch["input_ids"],
-            },
-            kwargs={
-                "labels": ctx.batch["labels"],
-                "position_ids": ctx.batch["position_ids"],
-            },
+            input=SequenceInput(input_ids=ctx.batch["input_ids"]),
+            shared=SequenceCausalLMShared(
+                sequence=SequenceShared(position_ids=ctx.batch["position_ids"]), labels=ctx.batch["labels"]
+            ),
             state=PerplexityState(labels=ctx.batch["labels"]),
         )
 
-    def process_outputs(self, ctx: ProcessOutputsContext[PerplexityState]):
-        logps = ctx.pipeline_results["logps"]
+    def process_outputs(self, ctx: ProcessOutputsContext[SequenceCausalLMOutput, PerplexityState]):
+        logps = ctx.pipeline_results.logps
 
         # Calculate number of valid tokens (ignoring the -100 padding)
         # This is crucial for variable length batches.

--- a/example/qwen3_moe/pretrain.py
+++ b/example/qwen3_moe/pretrain.py
@@ -41,6 +41,7 @@ from d9d.metric.impl.aggregation import SumMetric
 from d9d.model_state.mapper.adapters import identity_mapper_from_module
 from d9d.module.block.head import LM_IGNORE_INDEX
 from d9d.module.block.hidden_states_aggregator import HiddenStatesAggregationMode
+from d9d.module.model.io import SequenceCausalLMOutput, SequenceCausalLMShared, SequenceInput, SequenceShared
 from d9d.module.model.qwen3_moe import Qwen3MoEForCausalLM, Qwen3MoEForCausalLMParameters
 from d9d.module.parallelism.model.qwen3_moe import parallelize_qwen3_moe_for_causal_lm
 from pydantic import BaseModel
@@ -218,11 +219,15 @@ class SFTState(TypedDict):
     num_tokens: torch.Tensor
 
 
-class SFTTask(TrainTask[dict[str, torch.Tensor], SFTState]):
+class SFTTask(
+    TrainTask[dict[str, torch.Tensor], SequenceInput, SequenceCausalLMShared, SequenceCausalLMOutput, SFTState]
+):
     def __init__(self, dist_ctx: DistributedContext):
         self._dist_ctx = dist_ctx
 
-    def build_forward_inputs(self, ctx: BuildForwardInputsContext) -> BuildForwardInputsResult[SFTState]:
+    def build_forward_inputs(
+        self, ctx: BuildForwardInputsContext
+    ) -> BuildForwardInputsResult[SequenceInput, SequenceCausalLMShared, SFTState]:
         # ctx.batch contains the output of the Collator.
 
         labels = ctx.batch["labels"]
@@ -230,17 +235,13 @@ class SFTTask(TrainTask[dict[str, torch.Tensor], SFTState]):
         # Number of valid tokens (ignoring the -100 padding); crucial for variable length batches.
         num_tokens = (labels != LM_IGNORE_INDEX).sum()
 
-        # Return inputs for model.forward() plus the typed side-data for later stages.
-        # inputs are only for the first pipeline stage
-        # kwargs are the same for all the pipeline stages
+        # Return the pipeline input (first stage only) plus the shared input (every stage) and the
+        # typed side-data carried to loss/metric computation.
         return BuildForwardInputsResult(
-            inputs={
-                "input_ids": ctx.batch["input_ids"],
-            },
-            kwargs={
-                "labels": ctx.batch["labels"],
-                "position_ids": ctx.batch["position_ids"],
-            },
+            input=SequenceInput(input_ids=ctx.batch["input_ids"]),
+            shared=SequenceCausalLMShared(
+                sequence=SequenceShared(position_ids=ctx.batch["position_ids"]), labels=ctx.batch["labels"]
+            ),
             state=SFTState(labels=labels, num_tokens=num_tokens),
         )
 
@@ -257,9 +258,9 @@ class SFTTask(TrainTask[dict[str, torch.Tensor], SFTState]):
     def update_metrics(self, ctx: UpdateMetricsContext[SFTState]):
         ctx.metrics["num_tokens"].update(ctx.state["num_tokens"])
 
-    def compute_loss(self, ctx: ComputeLossContext[SFTState]) -> ComputeLossResult:
+    def compute_loss(self, ctx: ComputeLossContext[SequenceCausalLMOutput, SFTState]) -> ComputeLossResult:
         # Retrieve log_probs calculated by the model pipeline
-        logps = ctx.pipeline_results["logps"]
+        logps = ctx.pipeline_results.logps
 
         num_loss_tokens = ctx.state["num_tokens"]
 

--- a/test/d9d_test/metric/classification/test_confusion_matrix.py
+++ b/test/d9d_test/metric/classification/test_confusion_matrix.py
@@ -106,11 +106,9 @@ def test_execution_exceptions():
         ),
         # Case 3: Multilabel Micro Accuracy
         MetricCase(
-            factory_fn=lambda: confusion_matrix_metric()
-            .multilabel(num_classes=3, threshold=0.5)
-            .with_accuracy()
-            .micro()
-            .build(),
+            factory_fn=lambda: (
+                confusion_matrix_metric().multilabel(num_classes=3, threshold=0.5).with_accuracy().micro().build()
+            ),
             initial_expect=torch.tensor(torch.nan),
             steps=[
                 MetricStep(
@@ -279,11 +277,13 @@ def test_execution_exceptions():
         ),
         # Case 10: Extensibility - Custom Statistic Calculation
         MetricCase(
-            factory_fn=lambda: confusion_matrix_metric()
-            .multiclass(num_classes=3)
-            .with_statistic(lambda m: m.tp.float())
-            .per_class()
-            .build(),
+            factory_fn=lambda: (
+                confusion_matrix_metric()
+                .multiclass(num_classes=3)
+                .with_statistic(lambda m: m.tp.float())
+                .per_class()
+                .build()
+            ),
             initial_expect=torch.tensor([0.0, 0.0, 0.0]),
             steps=[
                 MetricStep(

--- a/test/d9d_test/modules/model/sequence/causal_lm/test_distributed.py
+++ b/test/d9d_test/modules/model/sequence/causal_lm/test_distributed.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from d9d.core.dist_context import DeviceMeshParameters
+from d9d.module.model.io import SequenceCausalLMOutput, SequenceCausalLMShared, SequenceInput, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from d9d.pipelining.factory import PipelineScheduleGPipeConfig, build_schedule
 from torch import nn
@@ -47,17 +48,18 @@ def test_consistent_to_itself_dist(
     # Create Global Model and its Outputs
     model_global = model_factory_d9d(stage_global)
     outputs_global = model_global(
-        input_ids=batch_global.sequence.input_ids,
-        position_ids=batch_global.sequence.position_ids,
-        labels=batch_global.labels,
+        SequenceInput(input_ids=batch_global.sequence.input_ids),
+        SequenceCausalLMShared(
+            sequence=SequenceShared(position_ids=batch_global.sequence.position_ids), labels=batch_global.labels
+        ),
     )
-    loss_global = outputs_global["logps"][batch_global.labels != -100].sum() / loss_delimiter
+    loss_global = outputs_global.logps[batch_global.labels != -100].sum() / loss_delimiter
     loss_global.backward()
 
     # Create Local Model and PP Schedule
-    def _callback(outputs: dict[str, torch.Tensor], microbatch_idx: int) -> torch.Tensor:
+    def _callback(outputs: SequenceCausalLMOutput, microbatch_idx: int) -> torch.Tensor:
         labels_mb = microbatch_slice(batch_dist.labels, microbatch_idx=microbatch_idx, n_microbatches=_N_MICROBATCHES)
-        loss_value = outputs["logps"][labels_mb != -100].sum() / loss_delimiter
+        loss_value = outputs.logps[labels_mb != -100].sum() / loss_delimiter
         dist_loss_accum.append(loss_value.detach())
         return loss_value
 
@@ -75,21 +77,25 @@ def test_consistent_to_itself_dist(
 
     # Run Local Model
     inputs_microbatches = tuple(
-        {"input_ids": microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)}
+        SequenceInput(
+            input_ids=microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)
+        )
         for i in range(_N_MICROBATCHES)
     )
-    kwargs_microbatches = tuple(
-        {
-            "position_ids": microbatch_slice(
-                batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+    shared_microbatches = tuple(
+        SequenceCausalLMShared(
+            sequence=SequenceShared(
+                position_ids=microbatch_slice(
+                    batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+                )
             ),
-            "labels": microbatch_slice(batch_dist.labels, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
-        }
+            labels=microbatch_slice(batch_dist.labels, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
+        )
         for i in range(_N_MICROBATCHES)
     )
     schedule_info.schedule.step(
         inputs_microbatches=inputs_microbatches,
-        kwargs_microbatches=kwargs_microbatches,
+        shared_microbatches=shared_microbatches,
         callback=_callback,
     )
 

--- a/test/d9d_test/modules/model/sequence/causal_lm/test_hf.py
+++ b/test/d9d_test/modules/model/sequence/causal_lm/test_hf.py
@@ -1,4 +1,5 @@
 import pytest
+from d9d.module.model.io import SequenceCausalLMShared, SequenceInput, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.testing import assert_close
@@ -46,11 +47,12 @@ def test_consistent_to_hf(model_type: ModelCatalogue, model_factory_d9d):
     clone_module_weights(from_module=model_hf, to_module=model_d9d, map_with=HF_TO_D9D_MAPPER_CAUSAL_LM[model_type])
 
     outputs_d9d = model_d9d(
-        input_ids=batch.sequence.input_ids[:, :-1],
-        position_ids=batch.sequence.position_ids[:, :-1],
-        labels=labels_shift,
+        SequenceInput(input_ids=batch.sequence.input_ids[:, :-1]),
+        SequenceCausalLMShared(
+            sequence=SequenceShared(position_ids=batch.sequence.position_ids[:, :-1]), labels=labels_shift
+        ),
     )
-    loss_d9d = outputs_d9d["logps"][labels_shift != -100].mean()
+    loss_d9d = outputs_d9d.logps[labels_shift != -100].mean()
     loss_d9d.backward()
 
     assert_close(loss_d9d, outputs_hf.loss, atol=1e-4, rtol=0.001)

--- a/test/d9d_test/modules/model/sequence/classification/test_distributed.py
+++ b/test/d9d_test/modules/model/sequence/classification/test_distributed.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 from d9d.core.dist_context import DeviceMeshParameters
+from d9d.module.model.io import SequenceClassificationOutput, SequenceInput, SequencePoolingShared, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from d9d.pipelining.factory import PipelineScheduleGPipeConfig, build_schedule
 from torch import nn
@@ -47,17 +48,19 @@ def test_consistent_to_itself_dist(
     # Create Global Model and its Outputs
     model_global = model_factory_d9d(stage_global)
     outputs_global = model_global(
-        input_ids=batch_global.sequence.input_ids,
-        position_ids=batch_global.sequence.position_ids,
-        pooling_mask=batch_global.pooling_mask,
+        SequenceInput(input_ids=batch_global.sequence.input_ids),
+        SequencePoolingShared(
+            sequence=SequenceShared(position_ids=batch_global.sequence.position_ids),
+            pooling_mask=batch_global.pooling_mask,
+        ),
     )
-    loss_global = F.cross_entropy(outputs_global["scores"], batch_global.labels)
+    loss_global = F.cross_entropy(outputs_global.scores, batch_global.labels)
     loss_global.backward()
 
     # Create Local Model and PP Schedule
-    def _callback(outputs: dict[str, torch.Tensor], microbatch_idx: int) -> torch.Tensor:
+    def _callback(outputs: SequenceClassificationOutput, microbatch_idx: int) -> torch.Tensor:
         labels_mb = microbatch_slice(batch_dist.labels, microbatch_idx=microbatch_idx, n_microbatches=_N_MICROBATCHES)
-        loss_value = F.cross_entropy(outputs["scores"], labels_mb, reduction="sum") / batch_global.labels.numel()
+        loss_value = F.cross_entropy(outputs.scores, labels_mb, reduction="sum") / batch_global.labels.numel()
         dist_loss_accum.append(loss_value.detach())
         return loss_value
 
@@ -75,20 +78,24 @@ def test_consistent_to_itself_dist(
 
     # Run Local Model
     inputs_microbatches = tuple(
-        {"input_ids": microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)}
+        SequenceInput(
+            input_ids=microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)
+        )
         for i in range(_N_MICROBATCHES)
     )
-    kwargs_microbatches = tuple(
-        {
-            "position_ids": microbatch_slice(
-                batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+    shared_microbatches = tuple(
+        SequencePoolingShared(
+            sequence=SequenceShared(
+                position_ids=microbatch_slice(
+                    batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+                )
             ),
-            "pooling_mask": microbatch_slice(batch_dist.pooling_mask, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
-        }
+            pooling_mask=microbatch_slice(batch_dist.pooling_mask, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
+        )
         for i in range(_N_MICROBATCHES)
     )
     schedule_info.schedule.step(
-        inputs_microbatches=inputs_microbatches, kwargs_microbatches=kwargs_microbatches, callback=_callback
+        inputs_microbatches=inputs_microbatches, shared_microbatches=shared_microbatches, callback=_callback
     )
 
     # Compare Loss & Grads

--- a/test/d9d_test/modules/model/sequence/classification/test_hf.py
+++ b/test/d9d_test/modules/model/sequence/classification/test_hf.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from d9d.module.model.io import SequenceInput, SequencePoolingShared, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.testing import assert_close
@@ -47,9 +48,12 @@ def test_consistent_to_hf(model_type: ModelCatalogue, model_factory_d9d):
     clone_module_weights(from_module=model_hf, to_module=model_d9d, map_with=HF_TO_D9D_MAPPER_CLS[model_type])
 
     outputs_d9d = model_d9d(
-        input_ids=batch.sequence.input_ids, position_ids=batch.sequence.position_ids, pooling_mask=batch.pooling_mask
+        SequenceInput(input_ids=batch.sequence.input_ids),
+        SequencePoolingShared(
+            sequence=SequenceShared(position_ids=batch.sequence.position_ids), pooling_mask=batch.pooling_mask
+        ),
     )
-    scores = outputs_d9d["scores"]
+    scores = outputs_d9d.scores
     assert scores.dtype == torch.float32
 
     assert_kl_div_close_logits(scores.bfloat16(), outputs_hf.logits, threshold=1e-3)

--- a/test/d9d_test/modules/model/sequence/embedding/test_distributed.py
+++ b/test/d9d_test/modules/model/sequence/embedding/test_distributed.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from d9d.core.dist_context import DeviceMeshParameters
+from d9d.module.model.io import SequenceEmbeddingOutput, SequenceInput, SequencePoolingShared, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from d9d.pipelining.factory import PipelineScheduleGPipeConfig, build_schedule
 from torch import nn
@@ -46,18 +47,20 @@ def test_consistent_to_itself_dist(
     # Create Global Model and its Outputs
     model_global = model_factory_d9d(stage_global)
     outputs_global = model_global(
-        input_ids=batch_global.sequence.input_ids,
-        position_ids=batch_global.sequence.position_ids,
-        pooling_mask=batch_global.pooling_mask,
+        SequenceInput(input_ids=batch_global.sequence.input_ids),
+        SequencePoolingShared(
+            sequence=SequenceShared(position_ids=batch_global.sequence.position_ids),
+            pooling_mask=batch_global.pooling_mask,
+        ),
     )
 
     # Use MSE-style dummy loss for embedding gradient tests
-    loss_global = outputs_global["embeddings"].mean()
+    loss_global = outputs_global.embeddings.mean()
     loss_global.backward()
 
     # Create Local Model and PP Schedule
-    def _callback(outputs: dict[str, torch.Tensor], microbatch_idx: int) -> torch.Tensor:
-        loss_value = outputs["embeddings"].sum() / batch_global.pooling_mask.sum() / outputs["embeddings"].shape[1]
+    def _callback(outputs: SequenceEmbeddingOutput, microbatch_idx: int) -> torch.Tensor:
+        loss_value = outputs.embeddings.sum() / batch_global.pooling_mask.sum() / outputs.embeddings.shape[1]
         dist_loss_accum.append(loss_value.detach())
         return loss_value
 
@@ -75,20 +78,24 @@ def test_consistent_to_itself_dist(
 
     # Run Local Model
     inputs_microbatches = tuple(
-        {"input_ids": microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)}
+        SequenceInput(
+            input_ids=microbatch_slice(batch_dist.sequence.input_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES)
+        )
         for i in range(_N_MICROBATCHES)
     )
-    kwargs_microbatches = tuple(
-        {
-            "position_ids": microbatch_slice(
-                batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+    shared_microbatches = tuple(
+        SequencePoolingShared(
+            sequence=SequenceShared(
+                position_ids=microbatch_slice(
+                    batch_dist.sequence.position_ids, microbatch_idx=i, n_microbatches=_N_MICROBATCHES
+                )
             ),
-            "pooling_mask": microbatch_slice(batch_dist.pooling_mask, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
-        }
+            pooling_mask=microbatch_slice(batch_dist.pooling_mask, microbatch_idx=i, n_microbatches=_N_MICROBATCHES),
+        )
         for i in range(_N_MICROBATCHES)
     )
     schedule_info.schedule.step(
-        inputs_microbatches=inputs_microbatches, kwargs_microbatches=kwargs_microbatches, callback=_callback
+        inputs_microbatches=inputs_microbatches, shared_microbatches=shared_microbatches, callback=_callback
     )
 
     # Compare Loss & Grads

--- a/test/d9d_test/modules/model/sequence/embedding/test_hf.py
+++ b/test/d9d_test/modules/model/sequence/embedding/test_hf.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from d9d.module.model.io import SequenceInput, SequencePoolingShared, SequenceShared
 from d9d.pipelining.api import PipelineStageInfo
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
@@ -50,11 +51,12 @@ def test_consistent_to_hf(model_type: ModelCatalogue, model_factory_d9d) -> None
     clone_module_weights(from_module=model_hf, to_module=model_d9d, map_with=HF_TO_D9D_MAPPER_EMBEDDING[model_type])
 
     outputs_d9d = model_d9d(
-        input_ids=batch.sequence.input_ids,
-        position_ids=batch.sequence.position_ids,
-        pooling_mask=batch.pooling_mask,
+        SequenceInput(input_ids=batch.sequence.input_ids),
+        SequencePoolingShared(
+            sequence=SequenceShared(position_ids=batch.sequence.position_ids), pooling_mask=batch.pooling_mask
+        ),
     )
-    embeddings = outputs_d9d["embeddings"]
+    embeddings = outputs_d9d.embeddings
     assert embeddings.dtype == torch.float32
 
     assert_angle_and_norm_close(

--- a/test/d9d_test/pipelining/definitions.py
+++ b/test/d9d_test/pipelining/definitions.py
@@ -1,7 +1,19 @@
+import dataclasses
+
 import torch
 from d9d.core.autograd import GLOBAL_GRAD_CONTEXT, GradDirection
-from d9d.pipelining.api import ModuleSupportsPipelining, TensorSpec
+from d9d.pipelining.api import ModuleSupportsPipelining, StageBoundary, TensorSpec
 from torch import nn
+
+
+@dataclasses.dataclass
+class _Transfer:
+    x: torch.Tensor
+
+
+@dataclasses.dataclass
+class _Shared:
+    y: torch.Tensor
 
 
 class CustomMatmul(torch.autograd.Function):
@@ -37,23 +49,16 @@ class PipelineModel(nn.Module, ModuleSupportsPipelining):
         self.w3 = nn.Parameter(torch.randn(8, 8) / 4)
         self.act = nn.GELU()
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor):  # x is args (passed by), y is kwargs (inputs)
-        r = CustomMatmul.apply(x, self.w1, GradDirection.inputs, GradDirection.weight)
+    def forward(self, inputs: _Transfer, shared: _Shared) -> _Transfer:
+        r = CustomMatmul.apply(inputs.x, self.w1, GradDirection.inputs, GradDirection.weight)
         r = r * 1.05
         r = r @ self.w2
-        r = self.act(r) + y
+        r = self.act(r) + shared.y
         r = CustomMatmul.apply(r, self.w3, GradDirection.inputs, GradDirection.weight)
-        return {"x": r}
+        return _Transfer(x=r)
 
-    def infer_stage_inputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return {"x": TensorSpec(shape=(microbatch_inputs["x"].shape[0], 8), dtype=torch.float32)}
-
-    def infer_stage_outputs_from_pipeline_inputs(
-        self, microbatch_inputs: dict[str, torch.Tensor]
-    ) -> dict[str, TensorSpec]:
-        return {"x": TensorSpec(shape=(microbatch_inputs["x"].shape[0], 8), dtype=torch.float32)}
+    def stage_transfer_spec(self, pipeline_input: _Transfer, boundary: StageBoundary) -> _Transfer:
+        return _Transfer(x=TensorSpec(shape=(pipeline_input.x.shape[0], 8), dtype=torch.float32))
 
 
 def register_pp_hooks(model: PipelineModel) -> dict[str, int]:
@@ -101,7 +106,7 @@ def _snapshot_grad(model: PipelineModel, x: torch.Tensor, y: torch.Tensor) -> di
 
 
 def do_standard_backward(model: PipelineModel, x: torch.Tensor, y: torch.Tensor) -> dict[str, torch.Tensor]:
-    out = model(x, y)["x"]
+    out = model(_Transfer(x=x), _Shared(y=y)).x
     loss = out.mean()
     loss.backward()
     snapshot = _snapshot_grad(model, x, y)

--- a/test/d9d_test/pipelining/test_e2e.py
+++ b/test/d9d_test/pipelining/test_e2e.py
@@ -16,6 +16,8 @@ from d9d.pipelining.infra.stage import PipelineStage
 
 from d9d_test.pipelining.definitions import (
     PipelineModel,
+    _Shared,
+    _Transfer,
     build_pp_inputs,
     build_pp_model,
     check_pp_hooks_ran,
@@ -26,16 +28,16 @@ from d9d_test.pipelining.definitions import (
 
 def _assert_no_live_buffers(stage_object: PipelineStage):
     # P2P receive buffers are released once consumed, so none should linger after a step.
-    if stage_object._forward_comm is not None:
-        assert len(stage_object._forward_comm._live_buffers) == 0
-    if stage_object._backward_comm is not None:
-        assert len(stage_object._backward_comm._live_buffers) == 0
+    if stage_object._forward_receiver is not None:
+        assert len(stage_object._forward_receiver._live_buffers) == 0
+    if stage_object._backward_receiver is not None:
+        assert len(stage_object._backward_receiver._live_buffers) == 0
 
 
 def _do_standard_backward(stages: list[PipelineModel], x: torch.Tensor, y: torch.Tensor):
     x_in = x
     for stage in stages:
-        x_in = stage(x=x_in, y=y)["x"]
+        x_in = stage(_Transfer(x=x_in), _Shared(y=y)).x
     loss = x_in.sum()
     loss.backward()
     snapshot = [
@@ -97,9 +99,9 @@ def test_e2e(
 
     loss_seen_microbatches = []
 
-    def _loss_fn(microbatch: dict[str, torch.Tensor], microbatch_idx: int):
+    def _loss_fn(microbatch: _Transfer, microbatch_idx: int):
         loss_seen_microbatches.append(microbatch_idx)
-        return microbatch["x"].sum()
+        return microbatch.x.sum()
 
     schedule_info, _ = build_schedule(
         dist_context=dist_ctx,
@@ -109,11 +111,11 @@ def test_e2e(
 
     not_this_rank_stages = [i for i in range(len(full_stage_modules)) if i not in this_rank_stages]
 
-    inputs_microbatches = tuple({"x": x_mb} for x_mb in torch.tensor_split(x, n_microbatches, dim=0))
-    kwargs_microbatches = tuple({"y": y_mb} for y_mb in torch.tensor_split(y, n_microbatches, dim=0))
+    inputs_microbatches = tuple(_Transfer(x=x_mb) for x_mb in torch.tensor_split(x, n_microbatches, dim=0))
+    shared_microbatches = tuple(_Shared(y=y_mb) for y_mb in torch.tensor_split(y, n_microbatches, dim=0))
 
     schedule_info.schedule.step(
-        inputs_microbatches=inputs_microbatches, kwargs_microbatches=kwargs_microbatches, callback=_loss_fn
+        inputs_microbatches=inputs_microbatches, shared_microbatches=shared_microbatches, callback=_loss_fn
     )
 
     assert x.grad is None
@@ -165,9 +167,9 @@ def test_e2e_local(dist_ctx_factory, freeze_w1: bool):
         assert stage_info.current_stage == 0
         return model
 
-    def _loss_fn(result: dict[str, torch.Tensor], microbatch_idx: int):
+    def _loss_fn(result: _Transfer, microbatch_idx: int):
         assert microbatch_idx == 0
-        return result["x"].sum()
+        return result.x.sum()
 
     schedule_config = PipelineScheduleGPipeConfig()
 
@@ -183,7 +185,9 @@ def test_e2e_local(dist_ctx_factory, freeze_w1: bool):
     assert schedule_info.has_first_stage
     assert schedule_info.has_last_stage
 
-    schedule_info.schedule.step(inputs_microbatches=({"x": x},), kwargs_microbatches=({"y": y},), callback=_loss_fn)
+    schedule_info.schedule.step(
+        inputs_microbatches=(_Transfer(x=x),), shared_microbatches=(_Shared(y=y),), callback=_loss_fn
+    )
 
     if freeze_w1:
         assert model.w1.grad is None

--- a/test/d9d_test/pipelining/test_e2e_inference.py
+++ b/test/d9d_test/pipelining/test_e2e_inference.py
@@ -10,6 +10,8 @@ from d9d.pipelining.infra.schedule.component.runtime import OfflinePipelineExecu
 
 from d9d_test.pipelining.definitions import (
     PipelineModel,
+    _Shared,
+    _Transfer,
     build_pp_inputs,
     build_pp_model,
 )
@@ -19,7 +21,7 @@ def _do_standard_forward(stages: list[PipelineModel], x: torch.Tensor, y: torch.
     with torch.no_grad():
         x_in = x
         for stage in stages:
-            x_in = stage(x=x_in, y=y)["x"]
+            x_in = stage(_Transfer(x=x_in), _Shared(y=y)).x
     return x_in
 
 
@@ -63,8 +65,8 @@ def test_inference_e2e(dist_ctx_factory, microbatch_sizes: list[int]):
 
     collected_results: dict[int, torch.Tensor] = {}
 
-    def _result_fn(microbatch_outputs: dict[str, torch.Tensor], microbatch_idx: int):
-        collected_results[microbatch_idx] = microbatch_outputs["x"].detach().clone()
+    def _result_fn(microbatch_outputs: _Transfer, microbatch_idx: int):
+        collected_results[microbatch_idx] = microbatch_outputs.x.detach().clone()
 
     schedule_info, _ = build_schedule(
         dist_context=dist_ctx,
@@ -72,11 +74,11 @@ def test_inference_e2e(dist_ctx_factory, microbatch_sizes: list[int]):
         model_provider=_model_provider,
     )
 
-    inputs_microbatches = tuple({"x": x} for x in microbatch_xs)
-    kwargs_microbatches = tuple({"y": y} for y in microbatch_ys)
+    inputs_microbatches = tuple(_Transfer(x=x) for x in microbatch_xs)
+    shared_microbatches = tuple(_Shared(y=y) for y in microbatch_ys)
 
     schedule_info.schedule.step(
-        inputs_microbatches=inputs_microbatches, kwargs_microbatches=kwargs_microbatches, callback=_result_fn
+        inputs_microbatches=inputs_microbatches, shared_microbatches=shared_microbatches, callback=_result_fn
     )
 
     if pp_mesh.get_local_rank() == pp_mesh.size() - 1:
@@ -107,9 +109,9 @@ def test_inference_e2e_local(dist_ctx_factory):
 
     collected_results: dict[int, torch.Tensor] = {}
 
-    def _result_fn(microbatch_outputs: dict[str, torch.Tensor], microbatch_idx: int):
+    def _result_fn(microbatch_outputs: _Transfer, microbatch_idx: int):
         # Offline executor processes everything in one go, always index 0
-        collected_results[microbatch_idx] = microbatch_outputs["x"].detach().clone()
+        collected_results[microbatch_idx] = microbatch_outputs.x.detach().clone()
 
     schedule_info, _ = build_schedule(
         dist_context=dist_ctx,
@@ -119,7 +121,9 @@ def test_inference_e2e_local(dist_ctx_factory):
 
     assert isinstance(schedule_info.schedule, OfflinePipelineExecutor)
 
-    schedule_info.schedule.step(inputs_microbatches=({"x": x},), kwargs_microbatches=({"y": y},), callback=_result_fn)
+    schedule_info.schedule.step(
+        inputs_microbatches=(_Transfer(x=x),), shared_microbatches=(_Shared(y=y),), callback=_result_fn
+    )
 
     # trace should have exactly one result at index 0 because OfflineExecutor does not shard
     assert len(collected_results) == 1

--- a/test/d9d_test/pipelining/test_splitgrad.py
+++ b/test/d9d_test/pipelining/test_splitgrad.py
@@ -9,6 +9,8 @@ from d9d.pipelining.infra.stage.splitgrad import (
 )
 
 from d9d_test.pipelining.definitions import (
+    _Shared,
+    _Transfer,
     build_pp_inputs,
     build_pp_model,
     check_pp_hooks_ran,
@@ -27,7 +29,7 @@ def test_custom_backward_correctness():
 
     hook_state = register_pp_hooks(model)
 
-    loss = model(x, y)["x"].mean()
+    loss = model(_Transfer(x=x), _Shared(y=y)).x.mean()
 
     results = stage_backward_full(outputs=[loss], output_grads=[torch.ones_like(loss)], inputs=[x, y])
 
@@ -54,7 +56,7 @@ def test_split_backward_correctness():
 
     orig_snapshot = do_standard_backward(model, x, y)
 
-    loss = model(x, y)["x"].mean()
+    loss = model(_Transfer(x=x), _Shared(y=y)).x.mean()
 
     hook_state = register_pp_hooks(model)
 


### PR DESCRIPTION
# Reviewer Guide

Replaces the overloaded `dict[str, torch.Tensor]` with four named generic PyTree roles:
`PipelineInput` (into first stage), `StageTransfer` (between stages, the only thing on the wire),
`PipelineOutput` (out of last stage), `SharedInput` (to every stage). **Breaking public API, no shim.**

Review in this order:

1. **DEP** (`0010-dep-pipelining-pytree-io.md`)
2. **Tests/examples** - they show how this looks for end-user now.
3. **API** (`pipelining/api/`) - the TypeVars, generic `ModuleSupportsPipelining` (new `forward` signature, `stage_transfer_spec` + `StageBoundary`), generic `PipelineSchedule`.
4. **Pipelining Infra** (`pipelining/infra/`). Transfort - sender/receiver agree on wire order *by construction* (same dataclass ⇒ same `tree_flatten` order). `offline.py` is the simplest end-to-end read.
5. **Task API** (`loop/control/task.py`) - `BuildForwardInputsResult` now `input`/`shared`/`state`; contexts carry `TPipelineOutput`/`TState`.
6. **Models** (`module/model/io/sequence.py` + qwen3) - branch on `is_current_stage_first/last`, return dataclasses.
7. Anything else related to wiring
